### PR TITLE
feat(map): export interactive map surface from /advanced (/internal)

### DIFF
--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -520,6 +520,55 @@ export { parseRing } from './ring/parser';
 export { renderRing, renderRingForExport } from './ring/renderer';
 export type { ParsedRing, RingLayer } from './ring/types';
 
+// Map (§24B) — the interactive render surface for app/editor consumers. The
+// Node fs `loadMapData` is exported for completeness, but the browser supplies
+// `MapData` by DI (resolveMap/renderMap take it as an argument).
+export { parseMap, looksLikeMap } from './map/parser';
+export { resolveMap } from './map/resolver';
+export { loadMapData } from './map/load-data';
+export { layoutMap } from './map/layout';
+export type {
+  MapLayout,
+  MapLayoutRegion,
+  MapLayoutPoi,
+  MapLayoutLeg,
+  PlacedLabel,
+  MapLayoutLegend,
+} from './map/layout';
+export { renderMap, renderMapForExport } from './map/renderer';
+export type {
+  ParsedMap,
+  MapDirectives,
+  MapRegion,
+  MapPoi,
+  MapRoute,
+  MapEdge,
+  PoiPos,
+} from './map/types';
+export type {
+  ResolvedMap,
+  MapData,
+  ResolvedRegion,
+  ResolvedPoi,
+  ResolvedEdge,
+  ResolvedRoute,
+  ProjectionFamily,
+  GeoExtent,
+} from './map/resolved-types';
+export { completeMapPlaces, completeMapRegions } from './map/completion';
+export type {
+  MapPlaceCompletion,
+  MapRegionCompletion,
+  MapCompletionOptions,
+} from './map/completion';
+export type {
+  Gazetteer,
+  GazetteerEntry,
+  BoundaryTopology,
+  RegionName,
+  RegionNames,
+} from './map/data/types';
+
 export type { RaciDragSource, RaciInteractionHandlers } from './raci';
 export {
   parseRaci,


### PR DESCRIPTION
Follow-up to #4 (map chart type). Exposes the interactive map render + completion surface from `@diagrammo/dgmo/advanced` (= `/internal`) so consumers — diagrammo-app — can render maps and offer autocomplete.

Adds exports: `parseMap`, `looksLikeMap`, `resolveMap`, `loadMapData`, `layoutMap`, `renderMap`, `renderMapForExport`, `completeMapPlaces`, `completeMapRegions`, plus the `ParsedMap`/`ResolvedMap`/`MapData`/`MapLayout`/completion/data types.

Renderers pull d3-geo only into a consumer's lazy map chunk — eager imports (e.g. the editor importing only the pure `completeMap*` functions) tree-shake d3-geo out (verified in the app: eager boot chunks stay topojson-free; `sideEffects` is mostly false).

No behavior change; pure export surface addition. Typecheck + lint clean; build emits the types into `dist/advanced.d.ts` / `dist/internal.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)