### PR TITLE
feat(completion): per-type slot coverage parity — reference descriptor + extractors

### DIFF
--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -761,6 +761,10 @@ export {
   PIPE_METADATA,
   STRUCTURAL_KEYWORDS,
   TAG_SUPPORTING_TYPES,
+  REFERENCE_GRAMMAR,
+  RACI_MARKER_ALPHABETS,
+  WIREFRAME_FLAGS,
+  WIREFRAME_GROUP_ONLY_FLAGS,
   extractTagDeclarations,
 } from './completion';
 export type {
@@ -769,6 +773,7 @@ export type {
   DirectiveSpec,
   DirectiveValueSpec,
   PipeKeySpec,
+  ReferenceGrammar,
 } from './completion';
 
 export { parseFirstLine, ALL_CHART_TYPES } from './utils/parsing';

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -22,6 +22,13 @@ import {
   measureIndent,
 } from './utils/parsing';
 import { RECOGNIZED_COLOR_NAMES } from './colors';
+// Closed enum sets owned by their respective parsers — imported (never
+// hand-copied) so completion can't drift from the grammar (one-oracle rule).
+import { VARIANTS } from './raci/variants';
+import {
+  STATE_KEYWORDS as WIREFRAME_STATE_KEYWORDS,
+  GROUP_ONLY_METADATA as WIREFRAME_GROUP_ONLY_METADATA,
+} from './wireframe/parser';
 
 const RECOGNIZED_COLOR_SET: ReadonlySet<string> = new Set(
   RECOGNIZED_COLOR_NAMES
@@ -724,6 +731,114 @@ export const TAG_SUPPORTING_TYPES: ReadonlySet<string> = new Set(
     .filter(([, kws]) => kws.includes('tag'))
     .map(([type]) => type)
 );
+
+// ============================================================
+// Reference grammar descriptor (slot 5 — entity reference)
+// ============================================================
+
+/** Whether a chart type has a reference position (arrow/operator → a prior
+ *  declaration) and which operators open it. The single oracle that drives
+ *  the library extractor audit, the app's entity-trigger map, and the
+ *  conformance drift-guard — so the three can never disagree. v1 models
+ *  reference-after-operator only (NOT metadata-target references). */
+export interface ReferenceGrammar {
+  hasReferenceGrammar: boolean;
+  /** Literal operator tokens that introduce a reference (e.g. `->`, `<->`,
+   *  `~>`, `+`). The app derives its trigger regex from these (allowing the
+   *  labeled `-label->` / `~label~>` variants where applicable). */
+  referenceOperators: string[];
+}
+
+/**
+ * Per-type reference grammar. Grounded in each parser's arrow/operator
+ * grammar — NOT hand-typed blind. Types with no reference position (org,
+ * kanban, mindmap, all data charts, the radial/visualization types) declare
+ * `hasReferenceGrammar: false`. `map` references (`route A ~> B`) are owned by
+ * the app's bespoke geo-completion path, so it stays `false` here to avoid
+ * double-handling.
+ */
+export const REFERENCE_GRAMMAR = new Map<string, ReferenceGrammar>([
+  // Diagrams with a genuine reference position
+  ['sequence', { hasReferenceGrammar: true, referenceOperators: ['->', '~>'] }],
+  ['flowchart', { hasReferenceGrammar: true, referenceOperators: ['->'] }],
+  ['state', { hasReferenceGrammar: true, referenceOperators: ['->'] }],
+  ['sitemap', { hasReferenceGrammar: true, referenceOperators: ['->'] }],
+  [
+    'c4',
+    {
+      hasReferenceGrammar: true,
+      referenceOperators: ['->', '<->', '~>', '<~>'],
+    },
+  ],
+  // ER/class/infra reference grammars are irregular (cardinality / typed
+  // relationship operators / indented arrows); the app keeps a special-cased
+  // trigger for those, but they're still reference-grammar types here so the
+  // drift-guard covers their extractors.
+  ['er', { hasReferenceGrammar: true, referenceOperators: ['--'] }],
+  [
+    'class',
+    {
+      hasReferenceGrammar: true,
+      referenceOperators: ['-->', '--|>', '..|>', '*--', 'o--', '..>'],
+    },
+  ],
+  ['infra', { hasReferenceGrammar: true, referenceOperators: ['->'] }],
+  ['gantt', { hasReferenceGrammar: true, referenceOperators: ['->'] }],
+  ['pert', { hasReferenceGrammar: true, referenceOperators: ['->'] }],
+  ['arc', { hasReferenceGrammar: true, referenceOperators: ['->'] }],
+  ['sankey', { hasReferenceGrammar: true, referenceOperators: ['->', '--'] }],
+  ['chord', { hasReferenceGrammar: true, referenceOperators: ['->', '--'] }],
+  [
+    'boxes-and-lines',
+    { hasReferenceGrammar: true, referenceOperators: ['->', '<->'] },
+  ],
+  // Venn references prior sets via the `+` intersection operator (not an arrow).
+  ['venn', { hasReferenceGrammar: true, referenceOperators: ['+'] }],
+]);
+
+// Every other registered chart type has no reference position.
+for (const type of ALL_CHART_TYPES) {
+  if (!REFERENCE_GRAMMAR.has(type)) {
+    REFERENCE_GRAMMAR.set(type, {
+      hasReferenceGrammar: false,
+      referenceOperators: [],
+    });
+  }
+}
+
+// ============================================================
+// Closed value enums (slot 7) sourced from parser constants
+// ============================================================
+
+/**
+ * Per-RACI-variant marker alphabets (slot-7 enum in the role-assignment value
+ * position). Consumed by editor completion; sourced from `raci/variants.ts`'s
+ * `VARIANTS` so the marker set can never drift from the parser. Mirrored for
+ * the `rasci`/`daci` first-line keyword variants.
+ */
+export const RACI_MARKER_ALPHABETS: ReadonlyMap<string, readonly string[]> =
+  new Map([
+    ['raci', VARIANTS.raci.alphabet],
+    ['rasci', VARIANTS.rasci.alphabet],
+    ['daci', VARIANTS.daci.alphabet],
+  ]);
+
+/**
+ * Closed set of wireframe element state flags (slot-7 trailing enum, e.g.
+ * `(Submit) primary destructive`). Sourced from the wireframe parser's
+ * `STATE_KEYWORDS` — exported there and consumed here, never re-typed.
+ */
+export const WIREFRAME_FLAGS: readonly string[] = [...WIREFRAME_STATE_KEYWORDS];
+
+/**
+ * The subset of `WIREFRAME_FLAGS` that only make sense on group elements
+ * (`horizontal`/`scrollable`/`collapsed`). Editor completion drops these for
+ * non-group elements (buttons, dropdowns). Sourced from the parser's
+ * `GROUP_ONLY_METADATA`, never hand-copied.
+ */
+export const WIREFRAME_GROUP_ONLY_FLAGS: readonly string[] = [
+  ...WIREFRAME_GROUP_ONLY_METADATA,
+];
 
 // ============================================================
 // Pipe metadata for inline `| key value` on data lines
@@ -1818,7 +1933,8 @@ function extractArcSymbols(docText: string): DiagramSymbols {
 // Sankey extractor
 // ============================================================
 
-const SANKEY_ARROW_RE = /^(.+?)\s+->\s+(.+?)\s+(\d[\d,_.]*)/;
+// Sankey links accept both directed `->` and undirected `--` (echarts.ts §1.5).
+const SANKEY_ARROW_RE = /^(.+?)\s+(?:->|--)\s+(.+?)\s+(\d[\d,_.]*)/;
 
 function extractSankeySymbols(docText: string): DiagramSymbols {
   const lines = docText.split('\n');
@@ -1937,8 +2053,29 @@ function extractVennSymbols(docText: string): DiagramSymbols {
     // Skip indented intersection lines
     if (line[0] === ' ' || line[0] === '\t') continue;
 
-    // Set name (strip pipe metadata, alias, color)
-    const label = trimmed.split('|')[0]!.trim();
+    // Skip intersection rows — those are references to prior sets, not
+    // declarations. Set NAMES + aliases come from the declaration lines below
+    // (the `+`-completion offers those). Match the parser's detection (d3.ts:
+    // any `+` on the line = intersection), not just the spaced form.
+    if (trimmed.includes('+')) continue;
+
+    // Set declaration: `Name [as <alias>] [color]`. Emit both the clean name
+    // and the alias so `Set + ` reference completion can offer either token.
+    const work = trimmed.split('|')[0]!.trim();
+    const asMatch = work.match(/^(.+?)\s+as\s+([A-Za-z][\w-]*)\b/i);
+    if (asMatch) {
+      const name = asMatch[1]!.trim();
+      const alias = asMatch[2]!;
+      if (name && !entities.includes(name)) entities.push(name);
+      if (alias && !entities.includes(alias)) entities.push(alias);
+      continue;
+    }
+    // No alias — strip a trailing color token if present.
+    const colorMatch = work.match(/^(.+?)\s+(\S+)$/);
+    const label =
+      colorMatch && RECOGNIZED_COLOR_SET.has(colorMatch[2]!.toLowerCase())
+        ? colorMatch[1]!.trim()
+        : work;
     if (label && !entities.includes(label)) entities.push(label);
   }
 
@@ -2019,6 +2156,9 @@ function extractSlopeSymbols(docText: string): DiagramSymbols {
 // ============================================================
 
 const SERIES_RE = /^series\s+(.+)$/i;
+// "A -> B value" / "A -- B value" flow-link rows (chord/sankey via the shared
+// extractor). Both endpoints captured; trailing weight optional.
+const DATA_EDGE_RE = /^(.+?)\s+(?:->|--)\s+(.+?)(?:\s+-?\d[\d,_.]*)?\s*$/;
 
 function extractDataChartSymbols(docText: string): DiagramSymbols {
   const lines = docText.split('\n');
@@ -2050,6 +2190,34 @@ function extractDataChartSymbols(docText: string): DiagramSymbols {
       continue;
     }
 
+    // Edge rows (chord / flow links): "A -> B value" / "A -- B value" — recover
+    // BOTH endpoints. Without this the trailing-number scan below mangles the
+    // whole "A -> B" into a single junk entity.
+    const edgeMatch = trimmed.match(DATA_EDGE_RE);
+    if (edgeMatch) {
+      const src = edgeMatch[1]!.trim();
+      const dst = edgeMatch[2]!.trim();
+      if (src && !entities.includes(src)) entities.push(src);
+      if (dst && !entities.includes(dst)) entities.push(dst);
+      continue;
+    }
+
+    // Label-expression rows (function curves §15.4): "Name: expression". ONLY
+    // for `function` — other data charts have no colon-form and would otherwise
+    // truncate legitimate colon-bearing labels (`12:00 5` → `12`). Column-0
+    // only, so indented `key: value` metadata is never misread as an entity.
+    if (chartType === 'function') {
+      const indent = line.length - line.trimStart().length;
+      const colonIdx = trimmed.indexOf(':');
+      if (indent === 0 && colonIdx > 0) {
+        const beforeColon = trimmed.slice(0, colonIdx).trim();
+        if (beforeColon && !METADATA_KEY_SET.has(beforeColon.toLowerCase())) {
+          if (!entities.includes(beforeColon)) entities.push(beforeColon);
+          continue;
+        }
+      }
+    }
+
     // Data rows: "Label value [value...] [color]"
     const numIdx = trimmed.search(/\s-?\d/);
     if (numIdx > 0) {
@@ -2059,6 +2227,64 @@ function extractDataChartSymbols(docText: string): DiagramSymbols {
   }
 
   return { kind: chartType, entities };
+}
+
+// ============================================================
+// Wireframe extractor
+// ============================================================
+
+// Wireframe element grammar is not a numeric-row variant, so it earns its own
+// extractor: `[label]` fields, `(button)`, `{a | b}` dropdowns/selects, with
+// possibly several elements per line. Returns the element labels as entities.
+const WF_FIELD_RE = /\[([^\]]*)\]/g;
+const WF_BUTTON_RE = /\(([^)]+)\)/g;
+const WF_DROPDOWN_RE = /\{([^}]+)\}/g;
+
+function extractWireframeSymbols(docText: string): DiagramSymbols {
+  const lines = docText.split('\n');
+  const entities: string[] = [];
+  let pastFirstLine = false;
+
+  const push = (s: string): void => {
+    // Strip any legacy trailing `| meta` inside a bracket; the `{a|b}` pipe is
+    // handled separately by the dropdown split below.
+    const t = s.split('|')[0]!.trim();
+    if (t && !entities.includes(t)) entities.push(t);
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('//')) continue;
+
+    if (!pastFirstLine) {
+      pastFirstLine = true;
+      continue;
+    }
+
+    const firstToken = trimmed.split(/\s+/)[0]!.toLowerCase();
+    if (METADATA_KEY_SET.has(firstToken)) continue;
+
+    // `[label]` input/group fields.
+    for (const m of trimmed.matchAll(WF_FIELD_RE)) {
+      const inner = m[1]!.trim();
+      if (inner) push(inner);
+    }
+    // `(button)` — skip radio markers `(*)` / `( )`.
+    for (const m of trimmed.matchAll(WF_BUTTON_RE)) {
+      const inner = m[1]!.trim();
+      if (inner === '*' || inner === '') continue;
+      push(inner);
+    }
+    // `{opt1 | opt2}` dropdown/select — each option is an entity (carve-out pipe).
+    for (const m of trimmed.matchAll(WF_DROPDOWN_RE)) {
+      for (const opt of m[1]!.split('|')) {
+        const t = opt.trim();
+        if (t && !entities.includes(t)) entities.push(t);
+      }
+    }
+  }
+
+  return { kind: 'wireframe', entities };
 }
 
 // ============================================================
@@ -2106,6 +2332,12 @@ registerExtractor('scatter', extractDataChartSymbols);
 registerExtractor('heatmap', extractDataChartSymbols);
 registerExtractor('funnel', extractDataChartSymbols);
 registerExtractor('chord', extractDataChartSymbols);
+// `function` (`Name: expr`) and `wordcloud` (`Word weight`) had NO extractor
+// registered — extractDiagramSymbols returned null for them. The generalized
+// shared extractor now handles the colon-label form, so register both.
+registerExtractor('function', extractDataChartSymbols);
+registerExtractor('wordcloud', extractDataChartSymbols);
+registerExtractor('wireframe', extractWireframeSymbols);
 
 function extractTechRadarSymbols(docText: string): DiagramSymbols {
   const entities: string[] = [];

--- a/src/wireframe/parser.ts
+++ b/src/wireframe/parser.ts
@@ -71,11 +71,17 @@ type MutableWireframeElement = Omit<
 /** Known wireframe option keys (header-phase options before content) */
 const KNOWN_OPTIONS = new Set(['palette', 'theme', 'active-tag']);
 
-/** Keywords that only make sense on groups — force group interpretation (EC1) */
-const GROUP_ONLY_METADATA = new Set(['horizontal', 'scrollable', 'collapsed']);
+/** Keywords that only make sense on groups — force group interpretation (EC1).
+ *  Exported so editor completion can drop them for non-group elements. */
+export const GROUP_ONLY_METADATA = new Set([
+  'horizontal',
+  'scrollable',
+  'collapsed',
+]);
 
-/** Recognized state keywords for pipe metadata */
-const STATE_KEYWORDS = new Set([
+/** Recognized state keywords for pipe metadata. Exported so editor completion
+ *  can consume the closed set directly instead of hand-copying it (one-oracle). */
+export const STATE_KEYWORDS = new Set([
   'disabled',
   'active',
   'selected',

--- a/tests/completion-conformance.test.ts
+++ b/tests/completion-conformance.test.ts
@@ -24,6 +24,8 @@ import {
   STRUCTURAL_KEYWORDS,
   TAG_SUPPORTING_TYPES,
   ALL_CHART_TYPES,
+  REFERENCE_GRAMMAR,
+  extractDiagramSymbols,
 } from '../src/internal';
 import { getAvailablePalettes } from '../src/palettes';
 
@@ -248,3 +250,78 @@ for (const f of fixtures) {
     }
   });
 }
+
+// ============================================================
+// Generative reference-grammar drift-guard (NOT the hand-maintained list above)
+// ============================================================
+//
+// The fixture suite above only covers a type once someone hand-adds an import,
+// so it can never catch a forgotten chart type. This block iterates
+// ALL_CHART_TYPES DIRECTLY and asserts the slot-5 invariant: every type whose
+// REFERENCE_GRAMMAR declares `hasReferenceGrammar: true` MUST have a registered
+// extractor that returns ≥1 entity on a reference fixture. A new `chartTypes`
+// entry with a reference grammar but no working extractor fails here at CI —
+// the "new chart type, forgot completion" failure class dies.
+//
+// Fixtures are minimal current-spec snippets (parser-verified). When a new
+// reference-grammar type lands, add its fixture here or the guard goes red.
+const REFERENCE_FIXTURES: Record<string, string> = {
+  sequence: 'sequence\nAuth -> API\n',
+  flowchart: 'flowchart\nStart -> End\n',
+  state: 'state\nIdle -> Running\n',
+  sitemap: 'sitemap\nHome\nAbout\n',
+  c4: 'c4\nperson User\nsystem App\nUser -> App\n',
+  er: 'er\nUsers\nOrders\nUsers 1--* Orders\n',
+  class: 'class\nUser\nOrder\nUser --|> Order\n',
+  infra: 'infra\nAPI\nCache\n  API -> Cache\n',
+  gantt: 'gantt\nDesign duration: 5d\nBuild duration: 3d\n',
+  pert: 'pert\nDesign 1 2 3\nBuild 2 3 4\n',
+  arc: 'arc\nA -> B\n',
+  sankey: 'sankey\nA -> B 10\n',
+  chord: 'chord\nA -> B 10\n',
+  'boxes-and-lines': 'boxes-and-lines\nA -> B\n',
+  venn: 'venn\nSwordsmanship as sw\nNavigation as nav\nsw + nav Overlap\n',
+};
+
+describe('reference-grammar drift-guard (generative over ALL_CHART_TYPES)', () => {
+  for (const type of ALL_CHART_TYPES) {
+    const grammar = REFERENCE_GRAMMAR.get(type);
+    if (!grammar?.hasReferenceGrammar) continue;
+
+    it(`'${type}' has a working extractor (slot-5 reference invariant)`, () => {
+      const fixture = REFERENCE_FIXTURES[type];
+      expect(
+        fixture,
+        `'${type}' declares hasReferenceGrammar: true in REFERENCE_GRAMMAR but has no reference fixture in this test. Add one so the drift-guard can prove its extractor works.`
+      ).toBeDefined();
+      if (!fixture) return;
+
+      const symbols = extractDiagramSymbols(fixture);
+      expect(
+        symbols,
+        `'${type}' has a reference grammar but extractDiagramSymbols returned null — no registered extractor. Register one in completion.ts.`
+      ).not.toBeNull();
+      expect(
+        symbols!.entities.length,
+        `'${type}' reference extractor returned zero entities for a fixture that declares some. Reference completion will never fire.`
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    it(`'${type}' declares at least one reference operator`, () => {
+      expect(
+        grammar.referenceOperators.length,
+        `'${type}' has hasReferenceGrammar: true but no referenceOperators — the app can't build a trigger.`
+      ).toBeGreaterThanOrEqual(1);
+    });
+  }
+
+  it('every ALL_CHART_TYPES entry has a REFERENCE_GRAMMAR descriptor', () => {
+    const missing = [...ALL_CHART_TYPES].filter(
+      (t) => !REFERENCE_GRAMMAR.has(t)
+    );
+    expect(
+      missing,
+      `These chart types have no REFERENCE_GRAMMAR entry — the auto-fill loop in completion.ts should cover every registered type.`
+    ).toEqual([]);
+  });
+});

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -9,8 +9,12 @@ import {
   METADATA_KEY_SET,
   ENTITY_TYPES,
   PIPE_METADATA,
+  REFERENCE_GRAMMAR,
+  RACI_MARKER_ALPHABETS,
+  WIREFRAME_FLAGS,
   extractTagDeclarations,
 } from '../src/completion';
+import { parseDgmo } from '../src/dgmo-router';
 import { extractSymbols as extractErSymbols } from '../src/er/parser';
 import { extractSymbols as extractFlowchartSymbols } from '../src/graph/flowchart-parser';
 import { extractSymbols as extractInfraSymbols } from '../src/infra/parser';
@@ -913,5 +917,188 @@ describe('COMPLETION_REGISTRY — tech-radar', () => {
     expect(pipe!.quadrant).toHaveProperty('color');
     expect(pipe!.blip).toHaveProperty('ring');
     expect(pipe!.blip).toHaveProperty('trend');
+  });
+});
+
+// ============================================================
+// Coverage-parity additions (completion-coverage-parity spec)
+// ============================================================
+
+describe('extractDataChartSymbols — function curves (F1 registration)', () => {
+  it('registers function and extracts Name: expr curve names', () => {
+    // Generalization alone is inert without registerExtractor('function', …) —
+    // this guards F1: extractDiagramSymbols must NOT return null for function.
+    const result = extractDiagramSymbols(
+      'function\nSigmoid: 1/(1+e^-x)\nLinear: x\n'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe('function');
+    expect(result!.entities).toEqual(['Sigmoid', 'Linear']);
+  });
+
+  it('does not misread an indented key: value metadata line as a curve', () => {
+    const result = extractDiagramSymbols(
+      'function\nSigmoid: 1/(1+e^-x)\n  color: blue\n'
+    );
+    expect(result!.entities).toEqual(['Sigmoid']);
+  });
+});
+
+describe('extractDataChartSymbols — chord edge endpoints', () => {
+  it('recovers BOTH endpoints of A -> B value instead of one junk entity', () => {
+    const result = extractDiagramSymbols('chord\nA -> B 10\nB -> C 5\n');
+    expect(result!.kind).toBe('chord');
+    expect(result!.entities).toEqual(['A', 'B', 'C']);
+    // The old classifier produced "A -> B" — assert that junk is gone.
+    expect(result!.entities).not.toContain('A -> B');
+  });
+});
+
+describe('extractWireframeSymbols', () => {
+  it('extracts [field], (button), and {a | b} option labels', () => {
+    const result = extractDiagramSymbols(
+      'wireframe\n[Email]\n(Submit)\n{Yes | No}\n'
+    );
+    expect(result!.kind).toBe('wireframe');
+    expect(result!.entities).toEqual(['Email', 'Submit', 'Yes', 'No']);
+  });
+
+  it('skips radio/checkbox markers but keeps real element labels', () => {
+    const result = extractDiagramSymbols(
+      'wireframe\n(*) Option A\n[Search] (Go)\n'
+    );
+    expect(result!.entities).toContain('Search');
+    expect(result!.entities).toContain('Go');
+    expect(result!.entities).not.toContain('*');
+  });
+});
+
+describe('extractVennSymbols — names + aliases for + references', () => {
+  it('emits clean set names and aliases, skipping intersection rows', () => {
+    const doc =
+      'venn Skill Overlap\nSwordsmanship as sw red\nNavigation as nav blue\nsw + nav Sea Raiders\n';
+    const result = extractDiagramSymbols(doc);
+    expect(result!.kind).toBe('venn');
+    expect(result!.entities).toContain('sw');
+    expect(result!.entities).toContain('nav');
+    expect(result!.entities).toContain('Swordsmanship');
+    // The intersection line is a reference, not a declaration.
+    expect(result!.entities).not.toContain('sw + nav Sea Raiders');
+  });
+});
+
+describe('REFERENCE_GRAMMAR descriptor', () => {
+  it('marks chord and venn as reference-grammar types', () => {
+    expect(REFERENCE_GRAMMAR.get('chord')?.hasReferenceGrammar).toBe(true);
+    expect(REFERENCE_GRAMMAR.get('venn')?.hasReferenceGrammar).toBe(true);
+    expect(REFERENCE_GRAMMAR.get('venn')?.referenceOperators).toEqual(['+']);
+  });
+
+  it('marks pure data charts and radial types as non-reference', () => {
+    for (const t of [
+      'bar',
+      'pie',
+      'org',
+      'kanban',
+      'mindmap',
+      'wordcloud',
+      'function',
+    ]) {
+      expect(REFERENCE_GRAMMAR.get(t)?.hasReferenceGrammar).toBe(false);
+    }
+  });
+
+  it('keeps map reference-free (geo completion owns route refs)', () => {
+    expect(REFERENCE_GRAMMAR.get('map')?.hasReferenceGrammar).toBe(false);
+  });
+});
+
+describe('marker + flag enums (Task 5)', () => {
+  it('exposes per-variant RACI marker alphabets from the parser source', () => {
+    expect(RACI_MARKER_ALPHABETS.get('raci')).toEqual(['R', 'A', 'C', 'I']);
+    expect(RACI_MARKER_ALPHABETS.get('rasci')).toEqual([
+      'R',
+      'A',
+      'S',
+      'C',
+      'I',
+    ]);
+    expect(RACI_MARKER_ALPHABETS.get('daci')).toEqual(['D', 'A', 'C', 'I']);
+  });
+
+  it('exposes the 16 wireframe flags', () => {
+    expect(WIREFRAME_FLAGS).toHaveLength(16);
+    expect(WIREFRAME_FLAGS).toContain('primary');
+    expect(WIREFRAME_FLAGS).toContain('destructive');
+    expect(WIREFRAME_FLAGS).toContain('disabled');
+  });
+});
+
+describe('round-trip integrity (AC11) — newly-completed tokens parse clean', () => {
+  const errorsOf = (doc: string): string[] =>
+    (parseDgmo(doc).diagnostics ?? [])
+      .filter((d) => d.severity === 'error')
+      .map((d) => d.code ?? d.message);
+
+  it('RACI/RASCI/DACI marker assignments produce no error', () => {
+    expect(errorsOf('raci\nDeploy\n  Dev: R A\n  Ops: C I\n')).toEqual([]);
+    expect(
+      errorsOf('rasci\nShip\n  Dev: R\n  PM: A\n  QA: S\n  Sec: C\n  Exec: I\n')
+    ).toEqual([]);
+    expect(errorsOf('daci\nDecide\n  Lead: D\n  Mgr: A\n  Eng: C\n')).toEqual(
+      []
+    );
+  });
+
+  it('wireframe state flags produce no error', () => {
+    expect(
+      errorsOf('wireframe\n(Submit) primary destructive\n[Email] disabled\n')
+    ).toEqual([]);
+  });
+
+  it('tech-radar ring assignment to a declared ring produces no error', () => {
+    const doc = [
+      'tech-radar',
+      'rings',
+      '  Adopt',
+      '  Trial',
+      'Techniques quadrant: top-right',
+      '  CI/CD ring: Adopt, trend: stable',
+      'Tools quadrant: top-left',
+      '  Vite ring: Trial, trend: up',
+      'Platforms quadrant: bottom-left',
+      '  K8s ring: Adopt, trend: stable',
+      'Languages quadrant: bottom-right',
+      '  Rust ring: Trial, trend: up',
+    ].join('\n');
+    expect(errorsOf(doc)).toEqual([]);
+  });
+});
+
+describe('coverage-parity review fixes (H1/H2/M1)', () => {
+  it('H1: data-chart colon-form gated to function — colon labels survive', () => {
+    // A bar row with a colon in the label must NOT be truncated to pre-colon.
+    expect(extractDiagramSymbols('bar\n12:00 5\n13:00 8\n')!.entities).toEqual([
+      '12:00',
+      '13:00',
+    ]);
+    // function still extracts the colon-label form.
+    expect(
+      extractDiagramSymbols('function\nSigmoid: 1/(1+e^-x)\n')!.entities
+    ).toEqual(['Sigmoid']);
+  });
+
+  it('H2: sankey undirected `--` links yield clean endpoints, not junk', () => {
+    const r = extractDiagramSymbols('sankey\nA -- B 10\nB -> C 5\n');
+    expect(r!.entities).toEqual(['A', 'B', 'C']);
+    expect(r!.entities).not.toContain('A -- B 10');
+  });
+
+  it('M1: venn skips no-space `+` intersection rows', () => {
+    const r = extractDiagramSymbols(
+      'venn\nAlpha as a\nBeta as b\na+b Overlap\n'
+    );
+    expect(r!.entities).not.toContain('a+b Overlap');
+    expect(r!.entities).toEqual(expect.arrayContaining(['a', 'b']));
   });
 });


### PR DESCRIPTION
## Summary

Brings code-completion to a consistent **per-type slot baseline** — every slot a chart type actually supports completes, with no false parity — driven by a single library oracle so the library, the app, and the conformance test can't drift.

## Changes
- **`REFERENCE_GRAMMAR` descriptor** (per type: `hasReferenceGrammar` + `referenceOperators`) — the single oracle for slot-5 entity-reference completion. Drives the extractor audit, the app's entity triggers, and a new generative conformance guard.
- **Generalized `extractDataChartSymbols`**: handles `function`'s `Name: expr` form (gated to `function` so colon-bearing labels on bar/line/etc. aren't truncated) and recovers both endpoints of `A -> B value` chord/sankey edge rows. Registered the previously-missing `function`/`wordcloud`/`wireframe` extractors.
- **New `extractWireframeSymbols`**; `extractVennSymbols` now emits clean set names + aliases and skips intersection rows (parser-aligned `+` detection).
- **Fixed sankey extractor** to accept undirected `--` links.
- **New enum exports** `RACI_MARKER_ALPHABETS`, `WIREFRAME_FLAGS`, `WIREFRAME_GROUP_ONLY_FLAGS` — sourced from parser constants, never hand-copied.
- **Generative drift-guard** over `ALL_CHART_TYPES`: every reference-grammar type must have a working registered extractor — kills the "new chart type, forgot completion" failure class.

## App side
Surfacing lands in the companion **diagrammo/app** PR (descriptor-derived triggers, pipe-path removal, new same-line enum handlers).

## Verification
- `pnpm typecheck` clean
- `pnpm test` — **6816 pass / 2 skipped**
- 0 lint errors
- Passed an adversarial code review (9 findings, all fixed + regression-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)