### PR TITLE
feat(advanced): export the 4 parser-integrated symbol extractors

### DIFF
--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -776,6 +776,15 @@ export type {
   ReferenceGrammar,
 } from './completion';
 
+// Parser-integrated symbol extractors (parser API, NOT "completion"). These 5
+// call the real parsers, so they stay in dgmo; the app calls them as a parser
+// (ADR-001 / Task 5 of the context-aware-completion spec). extractPertSymbols
+// is already exported above with the PERT surface.
+export { extractSymbols as extractErSymbols } from './er/parser';
+export { extractSymbols as extractFlowchartSymbols } from './graph/flowchart-parser';
+export { extractSymbols as extractInfraSymbols } from './infra/parser';
+export { extractSymbols as extractClassSymbols } from './class/parser';
+
 export { parseFirstLine, ALL_CHART_TYPES } from './utils/parsing';
 
 // ============================================================


### PR DESCRIPTION
Additive parser-API exports needed by the app's relocated completion dispatcher (context-aware-completion spec, Task 5 / ADR-001).

Exposes `extractSymbols` from er/flowchart/infra/class as `extractErSymbols` / `extractFlowchartSymbols` / `extractInfraSymbols` / `extractClassSymbols` from `/advanced` (+ `/internal`). `extractPertSymbols` is already public. The app calls these **as a parser** rather than re-implementing 5 production parsers; raw symbol extraction for these types stays in dgmo while completion orchestration moves to the app.

Additive only — existing completion exports unchanged (they're deleted later at the spec's Task 15, after parity cutover). dgmo tests **6818 pass**; knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)