### PR TITLE
feat(advanced)!: remove relocated completion exports (Task 15 — MERGE LAST)

### DIFF
--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -750,31 +750,15 @@ export type {
 // ============================================================
 // Completion (symbol extraction API)
 // ============================================================
+//
+// The completion registries + symbol extractors moved to the app (the only
+// consumer) — see ADR-001 of the context-aware-completion spec. dgmo no longer
+// publishes COMPLETION_REGISTRY / extractDiagramSymbols / STRUCTURAL_KEYWORDS /
+// REFERENCE_GRAMMAR / PIPE_METADATA / etc. The `DiagramSymbols` shape stays
+// exported — it is the return type of the parser-integrated extractors below,
+// which the app calls as a parser.
 
-export {
-  registerExtractor,
-  extractDiagramSymbols,
-  COMPLETION_REGISTRY,
-  CHART_TYPES,
-  METADATA_KEY_SET,
-  ENTITY_TYPES,
-  PIPE_METADATA,
-  STRUCTURAL_KEYWORDS,
-  TAG_SUPPORTING_TYPES,
-  REFERENCE_GRAMMAR,
-  RACI_MARKER_ALPHABETS,
-  WIREFRAME_FLAGS,
-  WIREFRAME_GROUP_ONLY_FLAGS,
-  extractTagDeclarations,
-} from './completion';
-export type {
-  DiagramSymbols,
-  ExtractFn,
-  DirectiveSpec,
-  DirectiveValueSpec,
-  PipeKeySpec,
-  ReferenceGrammar,
-} from './completion';
+export type { DiagramSymbols } from './completion-types';
 
 // Parser-integrated symbol extractors (parser API, NOT "completion"). These 5
 // call the real parsers, so they stay in dgmo; the app calls them as a parser

--- a/tests/completion-conformance.test.ts
+++ b/tests/completion-conformance.test.ts
@@ -18,15 +18,19 @@
  */
 import { describe, expect, it } from 'vitest';
 
+// Completion now lives in the app; dgmo no longer re-exports it from /internal
+// (ADR-001). dgmo keeps src/completion.ts internally as the home of the 5
+// parser-integrated extractors' registrations, so this drift-guard imports the
+// completion symbols directly from the module.
 import {
   COMPLETION_REGISTRY,
   PIPE_METADATA,
   STRUCTURAL_KEYWORDS,
   TAG_SUPPORTING_TYPES,
-  ALL_CHART_TYPES,
   REFERENCE_GRAMMAR,
   extractDiagramSymbols,
-} from '../src/internal';
+} from '../src/completion';
+import { ALL_CHART_TYPES } from '../src/internal';
 import { getAvailablePalettes } from '../src/palettes';
 
 import type { ConformanceFixture } from './fixtures/completion-conformance/_types';


### PR DESCRIPTION
⚠️ **MERGE LAST.** The single release-ordering-sensitive PR of the context-aware-completion relocation (Task 15 / ADR-001).

## Order
1. diagrammo/dgmo#13 (parser-extractor exports) → dgmo `main`
2. app #8 → #9 → #10 → #11 → #12 → app `main`
3. **then this PR** → dgmo `main`

If this merges before app #10–#12 reach app `main`, app `main` CI (which clones dgmo `main`) breaks, because pre-relocation app code still imports these symbols.

## What
Removes from `/advanced` (+ `/internal`): `COMPLETION_REGISTRY`, `extractDiagramSymbols`, `registerExtractor`, `CHART_TYPES`, `METADATA_KEY_SET`, `ENTITY_TYPES`, `PIPE_METADATA`, `STRUCTURAL_KEYWORDS`, `TAG_SUPPORTING_TYPES`, `REFERENCE_GRAMMAR`, `RACI_MARKER_ALPHABETS`, `WIREFRAME_FLAGS`, `WIREFRAME_GROUP_ONLY_FLAGS`, `extractTagDeclarations`.

**Kept**: the `DiagramSymbols` type (return type of the parser extractors), the 5 parser-integrated extractors, and `completeMapPlaces`/`completeMapRegions`.

`src/completion.ts` stays internally (strangler's accepted temporary duplication — it registers the 5 parser extractors); its drift-guard now imports from `../src/completion` directly. knip flags 2 now-internal-only exports (`TAG_SUPPORTING_TYPES`, `WIREFRAME_GROUP_ONLY_FLAGS`) as warnings — acceptable interim; a full `completion.ts` deletion is a follow-up.

**BREAKING** for `/advanced`+`/internal` consumers of those symbols — investigation confirmed the app is the only one, and post-relocation it no longer imports them. Permanently removes the cross-repo stale-pin / release-ordering hazard.

dgmo **6818 tests pass**; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)