### PR TITLE
refactor(echarts): split echarts.ts data-chart monolith (Epic 109.2a)

### DIFF
--- a/src/chart-type-registry.ts
+++ b/src/chart-type-registry.ts
@@ -137,6 +137,7 @@ function measureTechRadar(content: string): ContentCounts {
 
 function measureHeatmap(content: string): ContentCounts {
   const parsed = parseExtendedChart(content);
+  if (parsed.type !== 'heatmap') return { columns: 0, rows: 0 };
   return {
     columns: parsed.columns?.length ?? 0,
     rows: parsed.heatmapRows?.length ?? parsed.rows?.length ?? 0,

--- a/src/chart-type-registry.ts
+++ b/src/chart-type-registry.ts
@@ -35,7 +35,15 @@ import { parseState } from './graph/state-parser';
 import { parseClassDiagram } from './class/parser';
 import { parseERDiagram } from './er/parser';
 import { parseChart } from './chart';
-import { parseExtendedChart } from './echarts';
+import {
+  parseSankey,
+  parseChord,
+  parseFunctionChart,
+  parseScatter,
+  parseHeatmap,
+  parseFunnel,
+  EXTENDED_CHART_DOORS,
+} from './echarts';
 import { parseSlope } from './slope/parser';
 import { parseArc } from './arc/parser';
 import { parseTimeline } from './timeline/viz-parser';
@@ -136,8 +144,7 @@ function measureTechRadar(content: string): ContentCounts {
 }
 
 function measureHeatmap(content: string): ContentCounts {
-  const parsed = parseExtendedChart(content);
-  if (parsed.type !== 'heatmap') return { columns: 0, rows: 0 };
+  const parsed = parseHeatmap(content);
   return {
     columns: parsed.columns?.length ?? 0,
     rows: parsed.heatmapRows?.length ?? parsed.rows?.length ?? 0,
@@ -283,18 +290,18 @@ export const CHART_TYPE_REGISTRY: readonly ChartTypeDescriptor[] = [
   { id: 'polar-area', category: 'data-chart', parse: parseChart },
   { id: 'bar-stacked', category: 'data-chart', parse: parseChart },
 
-  // ── Extended ECharts charts (parseExtendedChart) ──────────
-  { id: 'scatter', category: 'data-chart', parse: parseExtendedChart },
-  { id: 'sankey', category: 'data-chart', parse: parseExtendedChart },
-  { id: 'chord', category: 'data-chart', parse: parseExtendedChart },
-  { id: 'function', category: 'data-chart', parse: parseExtendedChart },
+  // ── Extended ECharts charts — own per-type parser door (Story 109.2a) ──
+  { id: 'scatter', category: 'data-chart', parse: parseScatter },
+  { id: 'sankey', category: 'data-chart', parse: parseSankey },
+  { id: 'chord', category: 'data-chart', parse: parseChord },
+  { id: 'function', category: 'data-chart', parse: parseFunctionChart },
   {
     id: 'heatmap',
     category: 'data-chart',
-    parse: parseExtendedChart,
+    parse: parseHeatmap,
     measure: measureHeatmap,
   },
-  { id: 'funnel', category: 'data-chart', parse: parseExtendedChart },
+  { id: 'funnel', category: 'data-chart', parse: parseFunnel },
 
   // ── D3 visualizations — own per-viz parser door (Story 109.2) ──
   { id: 'slope', category: 'visualization', parse: parseSlope },
@@ -329,7 +336,11 @@ export const REGISTRY_BY_ID: ReadonlyMap<string, ChartTypeDescriptor> = new Map(
   CHART_TYPE_REGISTRY.map((d) => [d.id, d])
 );
 
-/** True when a type is rendered by the extended-ECharts parser. */
+/**
+ * True when a type is rendered by the extended-ECharts engine. Story 109.2a gave
+ * each extended type its own parser door, so this checks membership in the door
+ * set rather than identity against the single former `parseExtendedChart`.
+ */
 export function isExtendedChartParser(parse: ParseFn): boolean {
-  return parse === parseExtendedChart;
+  return EXTENDED_CHART_DOORS.has(parse);
 }

--- a/src/echarts.ts
+++ b/src/echarts.ts
@@ -107,8 +107,15 @@ interface ParsedHeatmapRow {
 
 import type { DgmoError } from './diagnostics';
 
-export interface ParsedExtendedChart {
-  type: ExtendedChartType;
+// ============================================================
+// Discriminated union — Story 109.2a (arch-review). Each extended data-chart
+// carries only its own type-specific fields; the parser fills a fat
+// `ParsedExtendedChartFull` accumulator and returns it narrowed (type-only,
+// runtime-identical). Shared fields live on ParsedExtendedBase.
+// ============================================================
+
+/** Fields shared by every extended data-chart. */
+export interface ParsedExtendedBase {
   title?: string;
   titleLineNumber?: number;
   series?: string;
@@ -117,18 +124,12 @@ export interface ParsedExtendedChart {
   seriesNameLineNumbers?: number[];
   seriesNameColors?: (string | undefined)[];
   data: ExtendedChartDataPoint[];
-  links?: ParsedSankeyLink[];
-  functions?: ParsedFunction[];
-  scatterPoints?: ParsedScatterPoint[];
-  heatmapRows?: ParsedHeatmapRow[];
-  columns?: string[];
-  rows?: string[];
-  xRange?: { min: number; max: number };
   xlabel?: string;
   xlabelLineNumber?: number;
   ylabel?: string;
   ylabelLineNumber?: number;
-  sizelabel?: string;
+  /** X-axis range — read by both function plots and scatter. */
+  xRange?: { min: number; max: number };
   noName?: boolean;
   noValue?: boolean;
   noPercent?: boolean;
@@ -142,6 +143,66 @@ export interface ParsedExtendedChart {
   nodeColors?: Record<string, string>;
   diagnostics: DgmoError[];
   error: string | null;
+}
+
+export interface ParsedSankey extends ParsedExtendedBase {
+  type: 'sankey';
+  links?: ParsedSankeyLink[];
+}
+
+export interface ParsedChord extends ParsedExtendedBase {
+  type: 'chord';
+  links?: ParsedSankeyLink[];
+}
+
+export interface ParsedFunctionChart extends ParsedExtendedBase {
+  type: 'function';
+  functions?: ParsedFunction[];
+}
+
+export interface ParsedScatter extends ParsedExtendedBase {
+  type: 'scatter';
+  scatterPoints?: ParsedScatterPoint[];
+  sizelabel?: string;
+}
+
+export interface ParsedHeatmap extends ParsedExtendedBase {
+  type: 'heatmap';
+  heatmapRows?: ParsedHeatmapRow[];
+  columns?: string[];
+  rows?: string[];
+}
+
+export interface ParsedFunnel extends ParsedExtendedBase {
+  type: 'funnel';
+}
+
+/** What `parseExtendedChart` returns: discriminated on `type`. */
+export type ParsedExtendedChart =
+  | ParsedSankey
+  | ParsedChord
+  | ParsedFunctionChart
+  | ParsedScatter
+  | ParsedHeatmap
+  | ParsedFunnel;
+
+/**
+ * The parser's mutable accumulator — every type-specific field present, so the
+ * single state machine can populate whichever the detected type needs.
+ * `parseExtendedChart` returns this narrowed to {@link ParsedExtendedChart}; the
+ * object is a structural superset of every variant, so the narrowing is sound
+ * and changes nothing at runtime.
+ */
+export interface ParsedExtendedChartFull extends ParsedExtendedBase {
+  type: ExtendedChartType;
+  links?: ParsedSankeyLink[];
+  functions?: ParsedFunction[];
+  scatterPoints?: ParsedScatterPoint[];
+  heatmapRows?: ParsedHeatmapRow[];
+  columns?: string[];
+  rows?: string[];
+  xRange?: { min: number; max: number };
+  sizelabel?: string;
 }
 
 // ============================================================
@@ -270,8 +331,15 @@ export function parseExtendedChart(
   content: string,
   palette?: PaletteColors
 ): ParsedExtendedChart {
+  return parseExtendedChartFull(content, palette) as ParsedExtendedChart;
+}
+
+function parseExtendedChartFull(
+  content: string,
+  palette?: PaletteColors
+): ParsedExtendedChartFull {
   const lines = content.split('\n');
-  const result: ParsedExtendedChart = {
+  const result: ParsedExtendedChartFull = {
     type: 'scatter',
     data: [],
     diagnostics: [],
@@ -979,7 +1047,7 @@ export function buildExtendedChartOption(
  * Builds ECharts option for sankey diagrams.
  */
 function buildSankeyOption(
-  parsed: ParsedExtendedChart,
+  parsed: ParsedSankey,
   textColor: string,
   colors: string[],
   bg: string,
@@ -1064,7 +1132,7 @@ function buildSankeyOption(
  * Builds ECharts option for chord diagrams.
  */
 function buildChordOption(
-  parsed: ParsedExtendedChart,
+  parsed: ParsedChord,
   palette: PaletteColors,
   isDark: boolean,
   textColor: string,
@@ -1231,7 +1299,7 @@ function evaluateExpression(expr: string, x: number): number {
  * Builds ECharts option for function plots.
  */
 function buildFunctionOption(
-  parsed: ParsedExtendedChart,
+  parsed: ParsedFunctionChart,
   palette: PaletteColors,
   _isDark: boolean,
   textColor: string,
@@ -1656,7 +1724,7 @@ function dataToPixel(
  * - hasSize → dynamic symbol sizing from 3rd value
  */
 function buildScatterOption(
-  parsed: ParsedExtendedChart,
+  parsed: ParsedScatter,
   palette: PaletteColors,
   isDark: boolean,
   textColor: string,
@@ -1959,7 +2027,7 @@ function buildScatterOption(
  * Builds ECharts option for heatmap charts.
  */
 function buildHeatmapOption(
-  parsed: ParsedExtendedChart,
+  parsed: ParsedHeatmap,
   palette: PaletteColors,
   isDark: boolean,
   textColor: string,
@@ -2168,7 +2236,7 @@ function buildHeatmapOption(
  * Builds ECharts option for funnel charts.
  */
 function buildFunnelOption(
-  parsed: ParsedExtendedChart,
+  parsed: ParsedFunnel,
   palette: PaletteColors,
   isDark: boolean,
   textColor: string,

--- a/src/echarts.ts
+++ b/src/echarts.ts
@@ -334,6 +334,65 @@ export function parseExtendedChart(
   return parseExtendedChartFull(content, palette) as ParsedExtendedChart;
 }
 
+// ============================================================
+// Per-type parser doors — Story 109.2a (arch-review). Each extended data-chart's
+// typed entry point into the shared parse state machine, returning its narrowed
+// variant. The registry binds each id to its own door; `isExtendedChartParser`
+// recognises them by set membership (they replace the old single-identity check).
+// ============================================================
+
+export function parseSankey(
+  content: string,
+  palette?: PaletteColors
+): ParsedSankey {
+  return parseExtendedChart(content, palette) as ParsedSankey;
+}
+
+export function parseChord(
+  content: string,
+  palette?: PaletteColors
+): ParsedChord {
+  return parseExtendedChart(content, palette) as ParsedChord;
+}
+
+export function parseFunctionChart(
+  content: string,
+  palette?: PaletteColors
+): ParsedFunctionChart {
+  return parseExtendedChart(content, palette) as ParsedFunctionChart;
+}
+
+export function parseScatter(
+  content: string,
+  palette?: PaletteColors
+): ParsedScatter {
+  return parseExtendedChart(content, palette) as ParsedScatter;
+}
+
+export function parseHeatmap(
+  content: string,
+  palette?: PaletteColors
+): ParsedHeatmap {
+  return parseExtendedChart(content, palette) as ParsedHeatmap;
+}
+
+export function parseFunnel(
+  content: string,
+  palette?: PaletteColors
+): ParsedFunnel {
+  return parseExtendedChart(content, palette) as ParsedFunnel;
+}
+
+/** The six extended-data-chart parser doors, for `isExtendedChartParser`. */
+export const EXTENDED_CHART_DOORS = new Set<unknown>([
+  parseSankey,
+  parseChord,
+  parseFunctionChart,
+  parseScatter,
+  parseHeatmap,
+  parseFunnel,
+]);
+
 function parseExtendedChartFull(
   content: string,
   palette?: PaletteColors


### PR DESCRIPTION
Story 109.2a (arch-review) — fast-follow of 109.2, applying the same pattern to the `echarts.ts` data-chart twin.

**Stacked on #16 (Story 109.2)** — base is the 109.2 branch.

## What changed
- `ParsedExtendedChart` → **discriminated union** (`ParsedSankey | ParsedChord | ParsedFunctionChart | ParsedScatter | ParsedHeatmap | ParsedFunnel`) over a shared base; parser returns a narrowed fat accumulator — **type-only, runtime-identical**. The six builders tightened to their variants.
- Six per-type parser **doors**; registry binds each id to its door; `isExtendedChartParser` switched from single-identity to `EXTENDED_CHART_DOORS` set membership.
- **Physical builder-module extraction declined + documented**: unlike the d3 renderers, the six extended builders share infrastructure (`buildChartCommons`, `ScaleContext`, axis/legend/grid helpers) with the nine out-of-scope simple-chart builders, so fragmenting them would drag in the simple-chart restructure. The union already removes the dead-field carrying; builders stay narrowed in place (right altitude). No cycle to clear here (echarts isn't in any madge cycle).

## Validation
6,831 tests, **83/83 gallery snapshots zero drift**, typecheck/build/check:all clean. Code review: zero bugs. App reconciliation (1 site) in the diagrammo/app PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)