### PR TITLE
refactor(collapse): one tree collapse engine — migrate org/sitemap/mindmap (Epic 110.1)

### DIFF
--- a/src/mindmap/collapse.ts
+++ b/src/mindmap/collapse.ts
@@ -4,6 +4,10 @@
 
 import type { MindmapNode } from './types';
 import type { Writable } from '../utils/brand';
+import {
+  collapseTree,
+  type TreeCollapseShape,
+} from '../utils/collapse-engine/tree';
 
 // ============================================================
 // Types
@@ -36,38 +40,16 @@ function cloneNode(node: MindmapNode): Writable<MindmapNode> {
   };
 }
 
-function countDescendants(node: MindmapNode): number {
-  let count = 0;
-  for (const child of node.children) {
-    count += 1 + countDescendants(child);
-  }
-  return count;
-}
-
-function computeHiddenCounts(
-  nodes: readonly MindmapNode[],
-  collapsedIds: Set<string>,
-  hiddenCounts: Map<string, number>
-): void {
-  for (const node of nodes) {
-    if (collapsedIds.has(node.id) && node.children.length > 0) {
-      hiddenCounts.set(node.id, countDescendants(node));
-    }
-    computeHiddenCounts(node.children, collapsedIds, hiddenCounts);
-  }
-}
-
-function pruneCollapsed(
-  node: Writable<MindmapNode>,
-  collapsedIds: Set<string>
-): void {
-  for (const child of node.children) {
-    pruneCollapsed(child as Writable<MindmapNode>, collapsedIds);
-  }
-  if (collapsedIds.has(node.id) && node.children.length > 0) {
-    node.children = [];
-  }
-}
+/** Mindmap shape: every node counts toward the hidden tally (no containers). */
+const MINDMAP_SHAPE: TreeCollapseShape<MindmapNode> = {
+  getId: (node) => node.id,
+  getChildren: (node) => node.children,
+  clone: cloneNode,
+  setChildren: (node, children) => {
+    (node as Writable<MindmapNode>).children = children as MindmapNode[];
+  },
+  countsAsHidden: () => true,
+};
 
 // ============================================================
 // Main
@@ -77,18 +59,9 @@ export function collapseMindmapTree(
   roots: readonly MindmapNode[],
   collapsedIds: Set<string>
 ): CollapsedMindmapResult {
-  const hiddenCounts = new Map<string, number>();
-
   if (collapsedIds.size === 0) {
-    return { roots: [...roots], hiddenCounts };
+    return { roots: [...roots], hiddenCounts: new Map() };
   }
 
-  computeHiddenCounts(roots, collapsedIds, hiddenCounts);
-
-  const clonedRoots = roots.map(cloneNode);
-  for (const root of clonedRoots) {
-    pruneCollapsed(root, collapsedIds);
-  }
-
-  return { roots: clonedRoots, hiddenCounts };
+  return collapseTree(roots, collapsedIds, MINDMAP_SHAPE);
 }

--- a/src/org/collapse.ts
+++ b/src/org/collapse.ts
@@ -4,6 +4,10 @@
 
 import type { Writable } from '../utils/brand';
 import type { OrgNode, ParsedOrg } from './parser';
+import {
+  collapseTree,
+  type TreeCollapseShape,
+} from '../utils/collapse-engine/tree';
 
 // ============================================================
 // Types
@@ -49,41 +53,16 @@ function cloneNode(node: OrgNode): Writable<OrgNode> {
   };
 }
 
-function countDescendants(node: OrgNode): number {
-  let count = 0;
-  for (const child of node.children) {
-    count += (child.isContainer ? 0 : 1) + countDescendants(child);
-  }
-  return count;
-}
-
-/** Compute hidden counts from the ORIGINAL (unpruned) tree so nested
- *  collapses don't lose ancestor descendant totals. */
-function computeHiddenCounts(
-  nodes: readonly OrgNode[],
-  collapsedIds: Set<string>,
-  hiddenCounts: Map<string, number>
-): void {
-  for (const node of nodes) {
-    if (collapsedIds.has(node.id) && node.children.length > 0) {
-      hiddenCounts.set(node.id, countDescendants(node));
-    }
-    computeHiddenCounts(node.children, collapsedIds, hiddenCounts);
-  }
-}
-
-/** Remove children of collapsed nodes on the cloned tree. */
-function pruneCollapsed(
-  node: Writable<OrgNode>,
-  collapsedIds: Set<string>
-): void {
-  for (const child of node.children) {
-    pruneCollapsed(child as Writable<OrgNode>, collapsedIds);
-  }
-  if (collapsedIds.has(node.id) && node.children.length > 0) {
-    node.children = [];
-  }
-}
+/** Org shape: containers don't count toward an ancestor's hidden tally. */
+const ORG_SHAPE: TreeCollapseShape<OrgNode> = {
+  getId: (node) => node.id,
+  getChildren: (node) => node.children,
+  clone: cloneNode,
+  setChildren: (node, children) => {
+    (node as Writable<OrgNode>).children = children as OrgNode[];
+  },
+  countsAsHidden: (node) => !node.isContainer,
+};
 
 // ============================================================
 // Main
@@ -93,28 +72,17 @@ export function collapseOrgTree(
   original: ParsedOrg,
   collapsedIds: Set<string>
 ): CollapsedOrgResult {
-  const hiddenCounts = new Map<string, number>();
-
   if (collapsedIds.size === 0) {
-    return { parsed: original, hiddenCounts };
+    return { parsed: original, hiddenCounts: new Map() };
   }
 
-  // Compute counts from the ORIGINAL tree before any pruning
-  computeHiddenCounts(original.roots, collapsedIds, hiddenCounts);
+  const { roots, hiddenCounts } = collapseTree(
+    original.roots,
+    collapsedIds,
+    ORG_SHAPE
+  );
 
-  // Deep-clone roots and prune collapsed subtrees
-  const clonedRoots = original.roots.map(cloneNode);
-  for (const root of clonedRoots) {
-    pruneCollapsed(root, collapsedIds);
-  }
-
-  return {
-    parsed: {
-      ...original,
-      roots: clonedRoots,
-    },
-    hiddenCounts,
-  };
+  return { parsed: { ...original, roots }, hiddenCounts };
 }
 
 // ============================================================

--- a/src/sitemap/collapse.ts
+++ b/src/sitemap/collapse.ts
@@ -4,6 +4,14 @@
 
 import type { SitemapNode, SitemapEdge, ParsedSitemap } from './types';
 import type { Writable } from '../utils/brand';
+import {
+  collapseTree,
+  type TreeCollapseShape,
+} from '../utils/collapse-engine/tree';
+import {
+  reterminateEdges,
+  type EdgeEndpointShape,
+} from '../utils/collapse-engine/tree-edges';
 
 // ============================================================
 // Types
@@ -33,83 +41,26 @@ function cloneNode(node: SitemapNode): Writable<SitemapNode> {
   };
 }
 
-function countDescendants(node: SitemapNode): number {
-  let count = 0;
-  for (const child of node.children) {
-    count += (child.isContainer ? 0 : 1) + countDescendants(child);
-  }
-  return count;
-}
+/** Sitemap shape: containers don't count toward an ancestor's hidden tally. */
+const SITEMAP_SHAPE: TreeCollapseShape<SitemapNode> = {
+  getId: (node) => node.id,
+  getChildren: (node) => node.children,
+  clone: cloneNode,
+  setChildren: (node, children) => {
+    (node as Writable<SitemapNode>).children = children as SitemapNode[];
+  },
+  countsAsHidden: (node) => !node.isContainer,
+};
 
-/** Compute hidden counts from the ORIGINAL (unpruned) tree. */
-function computeHiddenCounts(
-  nodes: readonly SitemapNode[],
-  collapsedIds: Set<string>,
-  hiddenCounts: Map<string, number>
-): void {
-  for (const node of nodes) {
-    if (collapsedIds.has(node.id) && node.children.length > 0) {
-      hiddenCounts.set(node.id, countDescendants(node));
-    }
-    computeHiddenCounts(node.children, collapsedIds, hiddenCounts);
-  }
-}
-
-/** Remove children of collapsed nodes on the cloned tree. */
-function pruneCollapsed(
-  node: Writable<SitemapNode>,
-  collapsedIds: Set<string>
-): void {
-  for (const child of node.children) {
-    pruneCollapsed(child as Writable<SitemapNode>, collapsedIds);
-  }
-  if (collapsedIds.has(node.id) && node.children.length > 0) {
-    node.children = [];
-  }
-}
-
-/** Collect all node IDs reachable in a tree. */
-function collectNodeIds(nodes: readonly SitemapNode[], ids: Set<string>): void {
-  for (const node of nodes) {
-    ids.add(node.id);
-    collectNodeIds(node.children, ids);
-  }
-}
-
-/**
- * Find the outermost visible ancestor for a hidden node.
- * Walk up the original tree to find which collapsed container should absorb the arrow.
- */
-function findVisibleAncestor(
-  nodeId: string,
-  parentMap: Map<string, string>,
-  visibleIds: Set<string>,
-  collapsedIds: Set<string>
-): string | null {
-  let current = nodeId;
-  while (true) {
-    const parentId = parentMap.get(current);
-    if (!parentId) return null;
-    // If the parent is visible and is a collapsed container, re-terminate here
-    if (visibleIds.has(parentId) && collapsedIds.has(parentId)) {
-      return parentId;
-    }
-    current = parentId;
-  }
-}
-
-/** Build nodeId → parentId map from the original tree. */
-function buildParentMap(
-  nodes: readonly SitemapNode[],
-  map: Map<string, string>
-): void {
-  for (const node of nodes) {
-    for (const child of node.children) {
-      map.set(child.id, node.id);
-      buildParentMap([child], map);
-    }
-  }
-}
+const SITEMAP_EDGE_SHAPE: EdgeEndpointShape<SitemapEdge> = {
+  getSource: (edge) => edge.sourceId,
+  getTarget: (edge) => edge.targetId,
+  withEndpoints: (edge, sourceId, targetId) => ({
+    ...edge,
+    sourceId,
+    targetId,
+  }),
+};
 
 // ============================================================
 // Main
@@ -119,86 +70,31 @@ export function collapseSitemapTree(
   original: ParsedSitemap,
   collapsedIds: Set<string>
 ): CollapsedSitemapResult {
-  const hiddenCounts = new Map<string, number>();
-
   if (collapsedIds.size === 0) {
-    return { parsed: original, hiddenCounts };
+    return { parsed: original, hiddenCounts: new Map() };
   }
 
-  // Compute counts from the ORIGINAL tree before pruning
-  computeHiddenCounts(original.roots, collapsedIds, hiddenCounts);
+  // Walk · filter · tally via the shared engine.
+  const { roots, hiddenCounts } = collapseTree(
+    original.roots,
+    collapsedIds,
+    SITEMAP_SHAPE
+  );
 
-  // Deep-clone roots and prune collapsed subtrees
-  const clonedRoots = original.roots.map(cloneNode);
-  for (const root of clonedRoots) {
-    pruneCollapsed(root, collapsedIds);
-  }
-
-  // Collect visible node IDs after pruning
-  const visibleIds = new Set<string>();
-  collectNodeIds(clonedRoots, visibleIds);
-
-  // Build parent map from the ORIGINAL tree for ancestor lookup
-  const parentMap = new Map<string, string>();
-  buildParentMap(original.roots, parentMap);
-
-  // Re-terminate edges that reference hidden nodes.
-  // No deduplication — multiple edges between the same collapsed pair are kept
-  // so each retains its own label (e.g. "settings" and "billing" both show).
-  // Layout uses dagre multigraph to route each edge separately.
-  const newEdges: SitemapEdge[] = [];
-
-  for (const edge of original.edges) {
-    let sourceId = edge.sourceId;
-    let targetId = edge.targetId;
-
-    const sourceVisible = visibleIds.has(sourceId);
-    const targetVisible = visibleIds.has(targetId);
-
-    if (sourceVisible && targetVisible) {
-      // Both visible — keep as-is
-      newEdges.push({ ...edge });
-      continue;
-    }
-
-    // Re-terminate hidden endpoints
-    if (!sourceVisible) {
-      const ancestor = findVisibleAncestor(
-        sourceId,
-        parentMap,
-        visibleIds,
-        collapsedIds
-      );
-      if (!ancestor) continue; // both endpoints hidden with no visible ancestor
-      sourceId = ancestor;
-    }
-    if (!targetVisible) {
-      const ancestor = findVisibleAncestor(
-        targetId,
-        parentMap,
-        visibleIds,
-        collapsedIds
-      );
-      if (!ancestor) continue;
-      targetId = ancestor;
-    }
-
-    // Remove self-loops (both endpoints re-terminated to same collapsed group)
-    if (sourceId === targetId) continue;
-
-    newEdges.push({
-      ...edge,
-      sourceId,
-      targetId,
-    });
-  }
+  // Remap: re-terminate edges that reference pruned nodes to their visible
+  // collapsed-container ancestor (parent-walk; no dedup — parallel edges keep
+  // distinct labels for dagre multigraph routing).
+  const edges = reterminateEdges(
+    original.roots,
+    roots,
+    original.edges,
+    collapsedIds,
+    SITEMAP_SHAPE,
+    SITEMAP_EDGE_SHAPE
+  );
 
   return {
-    parsed: {
-      ...original,
-      roots: clonedRoots,
-      edges: newEdges,
-    },
+    parsed: { ...original, roots, edges },
     hiddenCounts,
   };
 }

--- a/src/utils/collapse-engine/tree-edges.ts
+++ b/src/utils/collapse-engine/tree-edges.ts
@@ -1,0 +1,115 @@
+// ============================================================
+// Collapse Engine — edge re-termination for trees (Story 110.1)
+// ============================================================
+//
+// The remap phase for hierarchical chart types with cross-links (sitemap). An
+// edge whose endpoint was pruned is walked up the ORIGINAL tree to the
+// outermost visible collapsed-container ancestor and re-terminated there.
+// Matches sitemap semantics exactly: no dedup (parallel edges keep distinct
+// labels for multigraph routing), self-loops dropped, unreachable edges dropped.
+
+import type { TreeCollapseShape } from './tree';
+import { collectTreeIds } from './tree';
+
+type NodeShape<N> = Pick<TreeCollapseShape<N>, 'getId' | 'getChildren'>;
+
+export interface EdgeEndpointShape<E> {
+  getSource(edge: E): string;
+  getTarget(edge: E): string;
+  /** Return a copy of `edge` with re-terminated endpoints. */
+  withEndpoints(edge: E, source: string, target: string): E;
+}
+
+function buildParentMap<N>(
+  roots: readonly N[],
+  shape: NodeShape<N>
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const walk = (nodes: readonly N[]): void => {
+    for (const node of nodes) {
+      for (const child of shape.getChildren(node)) {
+        map.set(shape.getId(child), shape.getId(node));
+        walk([child]);
+      }
+    }
+  };
+  walk(roots);
+  return map;
+}
+
+/**
+ * Walk up the original tree to the outermost visible ancestor that is itself a
+ * collapsed container — the node that should absorb the edge endpoint.
+ */
+function findVisibleAncestor(
+  nodeId: string,
+  parentMap: Map<string, string>,
+  visibleIds: Set<string>,
+  collapsedIds: Set<string>
+): string | null {
+  let current = nodeId;
+  while (true) {
+    const parentId = parentMap.get(current);
+    if (!parentId) return null;
+    if (visibleIds.has(parentId) && collapsedIds.has(parentId)) {
+      return parentId;
+    }
+    current = parentId;
+  }
+}
+
+/**
+ * Re-terminate edges that reference pruned nodes. Both-visible edges pass
+ * through (shallow-copied via `withEndpoints`); a hidden endpoint re-terminates
+ * to its visible collapsed-container ancestor, or the edge is dropped if there
+ * is none; resulting self-loops are dropped.
+ */
+export function reterminateEdges<N, E>(
+  originalRoots: readonly N[],
+  prunedRoots: readonly N[],
+  edges: readonly E[],
+  collapsedIds: Set<string>,
+  nodeShape: NodeShape<N>,
+  edgeShape: EdgeEndpointShape<E>
+): E[] {
+  const visibleIds = collectTreeIds(prunedRoots, nodeShape);
+  const parentMap = buildParentMap(originalRoots, nodeShape);
+  const result: E[] = [];
+
+  for (const edge of edges) {
+    let sourceId = edgeShape.getSource(edge);
+    let targetId = edgeShape.getTarget(edge);
+    const sourceVisible = visibleIds.has(sourceId);
+    const targetVisible = visibleIds.has(targetId);
+
+    if (sourceVisible && targetVisible) {
+      result.push(edgeShape.withEndpoints(edge, sourceId, targetId));
+      continue;
+    }
+
+    if (!sourceVisible) {
+      const ancestor = findVisibleAncestor(
+        sourceId,
+        parentMap,
+        visibleIds,
+        collapsedIds
+      );
+      if (!ancestor) continue;
+      sourceId = ancestor;
+    }
+    if (!targetVisible) {
+      const ancestor = findVisibleAncestor(
+        targetId,
+        parentMap,
+        visibleIds,
+        collapsedIds
+      );
+      if (!ancestor) continue;
+      targetId = ancestor;
+    }
+
+    if (sourceId === targetId) continue;
+    result.push(edgeShape.withEndpoints(edge, sourceId, targetId));
+  }
+  return result;
+}

--- a/src/utils/collapse-engine/tree.ts
+++ b/src/utils/collapse-engine/tree.ts
@@ -1,0 +1,117 @@
+// ============================================================
+// Collapse Engine — polymorphic tree projection (Story 110.1)
+// ============================================================
+//
+// One engine owns the walk · filter · tally phases of collapse for the
+// hierarchical chart types (org, mindmap, sitemap). Each chart type supplies a
+// small `TreeCollapseShape` descriptor; the only genuine divergences across the
+// three — the per-node tally rule and the per-type deep clone — live in the
+// descriptor, not in copied algorithm bodies. Edge re-termination (sitemap)
+// lives in ./tree-edges.
+
+/** Per-chart-type descriptor that adapts a node shape to the collapse engine. */
+export interface TreeCollapseShape<N> {
+  /** Stable id matched against the collapsed-id set. */
+  getId(node: N): string;
+  /** A node's children (a readonly view of its live child array). */
+  getChildren(node: N): readonly N[];
+  /** Deep-clone a node into a mutable copy (children cloned recursively). */
+  clone(node: N): N;
+  /** Replace a (cloned, mutable) node's children. */
+  setChildren(node: N, children: readonly N[]): void;
+  /**
+   * Whether this node contributes 1 to an ancestor's hidden-descendant tally.
+   * org/sitemap exclude structural containers (`!isContainer`); mindmap counts
+   * every node. This is the count-rule divergence, surfaced as one predicate.
+   */
+  countsAsHidden(node: N): boolean;
+}
+
+export interface TreeCollapseResult<N> {
+  /** Deep-cloned roots with each collapsed node's subtree pruned. */
+  roots: N[];
+  /** nodeId → count of hidden descendants, computed from the ORIGINAL tree. */
+  hiddenCounts: Map<string, number>;
+}
+
+function countDescendants<N>(node: N, shape: TreeCollapseShape<N>): number {
+  let count = 0;
+  for (const child of shape.getChildren(node)) {
+    count +=
+      (shape.countsAsHidden(child) ? 1 : 0) + countDescendants(child, shape);
+  }
+  return count;
+}
+
+/** Tally hidden descendants from the ORIGINAL (unpruned) tree so nested
+ *  collapses don't lose ancestor totals. */
+function computeHiddenCounts<N>(
+  nodes: readonly N[],
+  collapsedIds: Set<string>,
+  hiddenCounts: Map<string, number>,
+  shape: TreeCollapseShape<N>
+): void {
+  for (const node of nodes) {
+    const children = shape.getChildren(node);
+    if (collapsedIds.has(shape.getId(node)) && children.length > 0) {
+      hiddenCounts.set(shape.getId(node), countDescendants(node, shape));
+    }
+    computeHiddenCounts(children, collapsedIds, hiddenCounts, shape);
+  }
+}
+
+/** Drop the children of collapsed nodes on the cloned tree. */
+function pruneCollapsed<N>(
+  node: N,
+  collapsedIds: Set<string>,
+  shape: TreeCollapseShape<N>
+): void {
+  for (const child of shape.getChildren(node)) {
+    pruneCollapsed(child, collapsedIds, shape);
+  }
+  if (
+    collapsedIds.has(shape.getId(node)) &&
+    shape.getChildren(node).length > 0
+  ) {
+    shape.setChildren(node, []);
+  }
+}
+
+/**
+ * Collapse a node tree: tally hidden-descendant counts from the original tree,
+ * then return deep-cloned roots with each collapsed node's subtree pruned.
+ * Never mutates the input.
+ *
+ * Callers that need reference identity with the original parsed object on an
+ * empty collapse set should short-circuit before calling this.
+ */
+export function collapseTree<N>(
+  roots: readonly N[],
+  collapsedIds: Set<string>,
+  shape: TreeCollapseShape<N>
+): TreeCollapseResult<N> {
+  const hiddenCounts = new Map<string, number>();
+  computeHiddenCounts(roots, collapsedIds, hiddenCounts, shape);
+
+  const clonedRoots = roots.map((root) => shape.clone(root));
+  for (const root of clonedRoots) {
+    pruneCollapsed(root, collapsedIds, shape);
+  }
+  return { roots: clonedRoots, hiddenCounts };
+}
+
+/** Collect every node id reachable from `roots`. */
+export function collectTreeIds<N>(
+  roots: readonly N[],
+  shape: Pick<TreeCollapseShape<N>, 'getId' | 'getChildren'>
+): Set<string> {
+  const ids = new Set<string>();
+  const walk = (nodes: readonly N[]): void => {
+    for (const node of nodes) {
+      ids.add(shape.getId(node));
+      walk(shape.getChildren(node));
+    }
+  };
+  walk(roots);
+  return ids;
+}

--- a/tests/boxes-and-lines-collapse.test.ts
+++ b/tests/boxes-and-lines-collapse.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseBoxesAndLines } from '../src/boxes-and-lines/parser';
+import { collapseBoxesAndLines } from '../src/boxes-and-lines/collapse';
+
+// Characterization tests for boxes-and-lines collapse. Before Story 110.1 this
+// was only exercised by a benchmark + incidental parser/layout tests. These pin
+// the flat-model behavior (label-keyed selection, __group_ virtual node, edge
+// dedup + self-loop drop, DIRECT child count) — the behavior that the 110.1
+// analysis found does NOT fit the tree engine and so stays bespoke.
+
+const HEADER = 'boxes-and-lines';
+
+describe('collapseBoxesAndLines', () => {
+  it('returns the original parsed object when nothing collapsed', () => {
+    const parsed = parseBoxesAndLines(`${HEADER}\n[AWS]\n  API\n  DB`);
+    const { parsed: result, collapsedChildCounts } = collapseBoxesAndLines(
+      parsed,
+      new Set()
+    );
+    expect(result).toBe(parsed); // same reference
+    expect(collapsedChildCounts.size).toBe(0);
+  });
+
+  it('removes children of a collapsed group and tallies DIRECT child count', () => {
+    const parsed = parseBoxesAndLines(`${HEADER}\n[AWS]\n  API\n  DB`);
+    const { parsed: result, collapsedChildCounts } = collapseBoxesAndLines(
+      parsed,
+      new Set(['AWS'])
+    );
+    expect(result.nodes.find((n) => n.label === 'API')).toBeUndefined();
+    expect(result.nodes.find((n) => n.label === 'DB')).toBeUndefined();
+    // Direct child count only (NOT recursive descendant count).
+    expect(collapsedChildCounts.get('AWS')).toBe(2);
+    // Collapsed group is dropped from groups[] (layout treats it as a node).
+    expect(result.groups.find((g) => g.label === 'AWS')).toBeUndefined();
+  });
+
+  it('redirects an external edge endpoint to the __group_ virtual node', () => {
+    const content = [
+      HEADER,
+      'Client',
+      '  -calls-> API',
+      '[AWS]',
+      '  API',
+      '  DB',
+    ].join('\n');
+    const parsed = parseBoxesAndLines(content);
+    const { parsed: result } = collapseBoxesAndLines(parsed, new Set(['AWS']));
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe('Client');
+    expect(result.edges[0].target).toBe('__group_AWS');
+  });
+
+  it('drops a self-loop when both endpoints collapse into the same group', () => {
+    const content = [HEADER, '[AWS]', '  API', '    -talks-> DB', '  DB'].join(
+      '\n'
+    );
+    const parsed = parseBoxesAndLines(content);
+    const { parsed: result } = collapseBoxesAndLines(parsed, new Set(['AWS']));
+    // API → DB both reroute to __group_AWS → self-loop → dropped.
+    expect(result.edges.filter((e) => e.source === e.target)).toHaveLength(0);
+  });
+
+  it('deduplicates edges that collapse to the same source|target|label', () => {
+    const content = [
+      HEADER,
+      'Client',
+      '  -hit-> API',
+      '  -hit-> DB',
+      '[AWS]',
+      '  API',
+      '  DB',
+    ].join('\n');
+    const parsed = parseBoxesAndLines(content);
+    const { parsed: result } = collapseBoxesAndLines(parsed, new Set(['AWS']));
+    // Both Client→API and Client→DB reroute to Client→__group_AWS with label
+    // "hit" → deduplicated to one edge.
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].target).toBe('__group_AWS');
+  });
+});

--- a/tests/collapse-engine.test.ts
+++ b/tests/collapse-engine.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collapseTree,
+  collectTreeIds,
+  type TreeCollapseShape,
+} from '../src/utils/collapse-engine/tree';
+import {
+  reterminateEdges,
+  type EdgeEndpointShape,
+} from '../src/utils/collapse-engine/tree-edges';
+
+// Tests the collapse engine THROUGH ITS INTERFACE (descriptor invariants) with a
+// synthetic node/edge type — not through any one chart type. The per-chart tests
+// (org/sitemap/mindmap/sequence/boxes) cover the wiring; these cover the engine.
+
+interface TNode {
+  id: string;
+  isContainer: boolean;
+  children: TNode[];
+}
+interface TEdge {
+  from: string;
+  to: string;
+  tag?: string;
+}
+
+const node = (
+  id: string,
+  children: TNode[] = [],
+  isContainer = false
+): TNode => ({ id, isContainer, children });
+
+const cloneTNode = (n: TNode): TNode => ({
+  id: n.id,
+  isContainer: n.isContainer,
+  children: n.children.map(cloneTNode),
+});
+
+const makeShape = (countAll: boolean): TreeCollapseShape<TNode> => ({
+  getId: (n) => n.id,
+  getChildren: (n) => n.children,
+  clone: cloneTNode,
+  setChildren: (n, children) => {
+    n.children = children as TNode[];
+  },
+  countsAsHidden: (n) => (countAll ? true : !n.isContainer),
+});
+
+const edgeShape: EdgeEndpointShape<TEdge> = {
+  getSource: (e) => e.from,
+  getTarget: (e) => e.to,
+  withEndpoints: (e, from, to) => ({ ...e, from, to }),
+};
+
+describe('collapseTree (engine interface)', () => {
+  it('hides exactly the descendants of a collapsed node (count-all rule)', () => {
+    const roots = [node('root', [node('a', [node('a1')]), node('b')])];
+    const { roots: out, hiddenCounts } = collapseTree(
+      roots,
+      new Set(['root']),
+      makeShape(true)
+    );
+    expect(hiddenCounts.get('root')).toBe(3); // a, a1, b
+    expect(out[0].children).toHaveLength(0);
+  });
+
+  it('count rule excludes containers when the descriptor says so', () => {
+    const roots = [node('root', [node('grp', [node('x')], true), node('y')])];
+    const { hiddenCounts } = collapseTree(
+      roots,
+      new Set(['root']),
+      makeShape(false)
+    );
+    // grp is a container → 0; x → 1; y → 1 = 2 (vs 3 under count-all).
+    expect(hiddenCounts.get('root')).toBe(2);
+  });
+
+  it('filtered output contains no hidden descendant', () => {
+    const roots = [node('root', [node('a', [node('a1')])])];
+    const { roots: out } = collapseTree(roots, new Set(['a']), makeShape(true));
+    const visible = collectTreeIds(out, makeShape(true));
+    expect(visible.has('a')).toBe(true);
+    expect(visible.has('a1')).toBe(false); // pruned
+  });
+
+  it('tallies from the original tree for a nested collapse', () => {
+    const roots = [node('root', [node('a', [node('a1', [node('a2')])])])];
+    const { hiddenCounts } = collapseTree(
+      roots,
+      new Set(['a']),
+      makeShape(true)
+    );
+    expect(hiddenCounts.get('a')).toBe(2); // a1, a2
+  });
+
+  it('never mutates the input tree', () => {
+    const roots = [node('root', [node('a'), node('b')])];
+    collapseTree(roots, new Set(['root']), makeShape(true));
+    expect(roots[0].children).toHaveLength(2);
+  });
+
+  it('deep-clones even when nothing matches (no shared node refs)', () => {
+    const roots = [node('root', [node('a')])];
+    const { roots: out, hiddenCounts } = collapseTree(
+      roots,
+      new Set(['absent']),
+      makeShape(true)
+    );
+    expect(hiddenCounts.size).toBe(0);
+    expect(out[0]).not.toBe(roots[0]);
+    expect(out[0].children[0]).not.toBe(roots[0].children[0]);
+  });
+
+  it('records no count for a collapsed leaf', () => {
+    const roots = [node('root', [node('leaf')])];
+    const { hiddenCounts } = collapseTree(
+      roots,
+      new Set(['leaf']),
+      makeShape(true)
+    );
+    expect(hiddenCounts.has('leaf')).toBe(false);
+  });
+});
+
+describe('reterminateEdges (engine interface)', () => {
+  it('re-terminates hidden endpoints, drops self-loops, keeps visible edges', () => {
+    const roots = [
+      node('root', [
+        node('grp', [node('x'), node('y')], true),
+        node('outside'),
+      ]),
+    ];
+    const shape = makeShape(false);
+    const collapsed = new Set(['grp']);
+    const { roots: pruned } = collapseTree(roots, collapsed, shape);
+
+    const edges: TEdge[] = [
+      { from: 'outside', to: 'x', tag: 'in' }, // x hidden → reterminate to grp
+      { from: 'x', to: 'y', tag: 'internal' }, // both → grp → self-loop dropped
+      { from: 'outside', to: 'root', tag: 'keep' }, // both visible → kept
+    ];
+
+    const out = reterminateEdges(
+      roots,
+      pruned,
+      edges,
+      collapsed,
+      shape,
+      edgeShape
+    );
+
+    expect(out).toHaveLength(2);
+    const inEdge = out.find((e) => e.tag === 'in')!;
+    expect(inEdge.to).toBe('grp');
+    expect(out.find((e) => e.tag === 'internal')).toBeUndefined();
+    expect(out.find((e) => e.tag === 'keep')).toBeDefined();
+    // No edge terminates on a hidden node.
+    const visible = collectTreeIds(pruned, shape);
+    for (const e of out) {
+      expect(visible.has(e.from)).toBe(true);
+      expect(visible.has(e.to)).toBe(true);
+    }
+  });
+
+  it('does not dedup parallel edges that re-terminate to the same pair', () => {
+    const roots = [
+      node('root', [
+        node('grp', [node('x'), node('y')], true),
+        node('outside'),
+      ]),
+    ];
+    const shape = makeShape(false);
+    const collapsed = new Set(['grp']);
+    const { roots: pruned } = collapseTree(roots, collapsed, shape);
+
+    const edges: TEdge[] = [
+      { from: 'outside', to: 'x', tag: 'a' },
+      { from: 'outside', to: 'y', tag: 'b' },
+    ];
+    const out = reterminateEdges(
+      roots,
+      pruned,
+      edges,
+      collapsed,
+      shape,
+      edgeShape
+    );
+    // Both reroute to outside→grp but keep distinct labels (no dedup).
+    expect(out).toHaveLength(2);
+    expect(out.every((e) => e.to === 'grp')).toBe(true);
+  });
+});

--- a/tests/mindmap-collapse.test.ts
+++ b/tests/mindmap-collapse.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { parseMindmap } from '../src/mindmap/parser';
+import { collapseMindmapTree } from '../src/mindmap/collapse';
+
+// Characterization tests for mindmap collapse. Mindmap had no dedicated
+// collapse test before Story 110.1 — these pin current behavior (notably the
+// "count ALL children" tally rule, which differs from org/sitemap's
+// container-excluding rule) as the safety net for the collapse-engine refactor.
+
+describe('collapseMindmapTree', () => {
+  it('returns roots (shallow-copied) and empty counts when nothing collapsed', () => {
+    const parsed = parseMindmap('mindmap Root\n  Child');
+    const { roots, hiddenCounts } = collapseMindmapTree(
+      parsed.roots,
+      new Set()
+    );
+    expect(hiddenCounts.size).toBe(0);
+    expect(roots).toHaveLength(parsed.roots.length);
+    expect(roots[0].children).toHaveLength(1);
+  });
+
+  it('prunes children of a collapsed node and counts ALL descendants', () => {
+    const parsed = parseMindmap('mindmap Root\n  A\n    A1\n  B');
+    const rootId = parsed.roots[0].id;
+    const { roots, hiddenCounts } = collapseMindmapTree(
+      parsed.roots,
+      new Set([rootId])
+    );
+    expect(roots[0].children).toHaveLength(0);
+    // Unlike org/sitemap, mindmap has no isContainer exclusion: A, A1, B = 3.
+    expect(hiddenCounts.get(rootId)).toBe(3);
+  });
+
+  it('does not mutate the original roots', () => {
+    const parsed = parseMindmap('mindmap Root\n  A\n  B');
+    const rootId = parsed.roots[0].id;
+    collapseMindmapTree(parsed.roots, new Set([rootId]));
+    expect(parsed.roots[0].children).toHaveLength(2);
+  });
+
+  it('computes the hidden count from the ORIGINAL tree for a nested collapse', () => {
+    const parsed = parseMindmap('mindmap Root\n  A\n    A1\n      A2');
+    const aId = parsed.roots[0].children[0].id;
+    const { roots, hiddenCounts } = collapseMindmapTree(
+      parsed.roots,
+      new Set([aId])
+    );
+    // A1 + A2 are hidden under A = 2; Root stays expanded.
+    expect(hiddenCounts.get(aId)).toBe(2);
+    expect(roots[0].children[0].children).toHaveLength(0);
+  });
+
+  it('does not record a count for a collapsed leaf (no children)', () => {
+    const parsed = parseMindmap('mindmap Root\n  A');
+    const aId = parsed.roots[0].children[0].id;
+    const { hiddenCounts } = collapseMindmapTree(parsed.roots, new Set([aId]));
+    expect(hiddenCounts.has(aId)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Story 110.1 — One collapse engine, five shape descriptors (`arch-review`)

Collapses the duplicated collapse projection across the hierarchical chart types behind one polymorphic engine.

### What
- New `src/utils/collapse-engine/tree.ts` — `collapseTree(roots, collapsedIds, shape)` owns **walk · filter · tally** behind a `TreeCollapseShape<N>` descriptor (getId / getChildren / clone / setChildren / `countsAsHidden`).
- New `src/utils/collapse-engine/tree-edges.ts` — `reterminateEdges(...)` owns the **remap** phase (sitemap's parent-walk edge re-termination) behind `EdgeEndpointShape<E>`.
- **org / mindmap / sitemap** migrated: each drops its bespoke `computeHiddenCounts`/`pruneCollapsed`/`countDescendants` (and sitemap's edge-walk helpers) for an ~8-line descriptor. The count-rule divergence (container-excluding vs count-all) is now one predicate.

### Two-family finding (honest scope)
The five collapse modules are **two families**, not one. The **tree triad** (org/mindmap/sitemap) is a genuine isomorphism — that's this engine. **sequence + boxes-and-lines** are flat-model outliers (lineNumber/label selection, virtual-node minting, divergent dedup/self-loop/count semantics) sharing only a one-line endpoint lookup; folding them in would distort the engine, so they stay bespoke (per the story's AC3 option b). Their behavior is now locked by new characterization tests.

### Tests
+19: 9 engine-interface (synthetic node/edge, descriptor invariants) · 5 mindmap collapse · 5 boxes-and-lines collapse (the last two were coverage gaps).

### Verification
- `pnpm typecheck` clean · full suite **6850 pass / 2 skip** · **gallery snapshot 83/83 byte-identical** · `pnpm lint` 0 errors · knip/jscpd no new findings.
- **Deletion test:** org + sitemap + mindmap import the engine — deleting it re-scatters all four phases back into three renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)