### PR TITLE
feat(palettes): resolvePaletteOrFallback — one resolve·fallback·warn seam (Epic 110.2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ export function decodeDiagramUrl(url: string): DecodedDiagramUrl | null {
 // Palettes + themes (namespaces)
 // ============================================================
 
-export { palettes, getPalette } from './palettes';
+export { palettes, getPalette, resolvePaletteOrFallback } from './palettes';
 export { themes, type Theme } from './themes';
 
 // ============================================================

--- a/src/palettes/index.ts
+++ b/src/palettes/index.ts
@@ -4,6 +4,7 @@ export type { PaletteConfig, PaletteColors } from './types';
 // Re-export registry
 export {
   getPalette,
+  resolvePaletteOrFallback,
   getAvailablePalettes,
   registerPalette,
   isValidHex,

--- a/src/palettes/registry.ts
+++ b/src/palettes/registry.ts
@@ -81,9 +81,29 @@ export function registerPalette(palette: PaletteConfig): void {
   PALETTE_REGISTRY.set(palette.id, palette);
 }
 
-/** Get palette by id. Returns Nord if id is unrecognized (FR10). */
+/** Get palette by id. Silently returns the default palette if id is unrecognized. */
 export function getPalette(id: string): PaletteConfig {
   return PALETTE_REGISTRY.get(id) ?? PALETTE_REGISTRY.get(DEFAULT_PALETTE_ID)!;
+}
+
+/**
+ * Resolve a palette by id, falling back to the default palette when the id is
+ * unregistered. If a `warn` callback is supplied, it is invoked once with a
+ * human-readable fallback message on a miss — the single place the "resolve,
+ * fall back, warn" policy lives, so each host can surface it its own way
+ * (console.warn, Obsidian Notice, MCP response). Silent when the id resolves or
+ * when no callback is passed.
+ */
+export function resolvePaletteOrFallback(
+  id: string,
+  warn?: (message: string) => void
+): PaletteConfig {
+  const found = PALETTE_REGISTRY.get(id);
+  if (found) return found;
+  warn?.(
+    `Palette "${id}" is not registered — falling back to "${DEFAULT_PALETTE_ID}".`
+  );
+  return PALETTE_REGISTRY.get(DEFAULT_PALETTE_ID)!;
 }
 
 /** List all registered palettes alphabetically (for the selector UI). */

--- a/tests/palette-fallback.test.ts
+++ b/tests/palette-fallback.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+// Import from the palettes barrel so every palette module self-registers.
+import { resolvePaletteOrFallback } from '../src/palettes';
+
+// Story 110.2: the "resolve · fall back · warn" policy now lives in one place.
+// These pin the policy without a host (AC4).
+
+describe('resolvePaletteOrFallback', () => {
+  it('returns the requested palette when the id is registered', () => {
+    const warn = vi.fn();
+    const result = resolvePaletteOrFallback('nord', warn);
+    expect(result.id).toBe('nord');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default palette (slate) on an unknown id and warns', () => {
+    const warn = vi.fn();
+    const result = resolvePaletteOrFallback('does-not-exist', warn);
+    expect(result.id).toBe('slate');
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0][0];
+    expect(message).toContain('does-not-exist');
+    expect(message).toContain('slate');
+  });
+
+  it('is silent (no throw, no warn) when no logger is passed', () => {
+    const result = resolvePaletteOrFallback('still-not-real');
+    expect(result.id).toBe('slate');
+  });
+
+  it('does not warn when the requested id resolves, even with a logger', () => {
+    const warn = vi.fn();
+    resolvePaletteOrFallback('slate', warn);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Story 110.2 — Pull palette-fallback into one deep module (`arch-review`)

The "resolve palette id, fall back, warn" policy was written three ways (remark warns→nord, obsidian silent→nord, MCP none→slate). This adds the single seam in dgmo core.

### What
- `resolvePaletteOrFallback(id, warn?)` in `palettes/registry.ts` — resolves against the validated registry, falls back to the default palette (slate), and invokes an optional logger on a miss. Exported publicly from `@diagrammo/dgmo`.
- Fixed a stale comment on `getPalette` (said "Nord", returns the default).
- 4 unit tests pin the policy without a host (AC4).

### Consumer wiring (separate PRs, blocked on this publishing as 0.29.0)
- **remark-dgmo** → console.warn adapter (keeps prefix + location)
- **obsidian-dgmo** → silent (no logger)
- **dgmo-mcp** → surfaces the fallback message in the tool response (the warning it currently drops — AC3)

### Decision
Per maintainer call, the fallback **unifies to slate** — remark/obsidian previously fell back to nord; that's a deliberate, documented behavior change (the story's "no behavior change" AC was consciously overridden).

Additive, non-breaking. typecheck clean, full suite green, API baseline unchanged (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)