### PR TITLE
feat(cli): colorful ASCII logo for dgmo

### DIFF
--- a/src/cli-banner.ts
+++ b/src/cli-banner.ts
@@ -11,6 +11,8 @@
 // and NO_COLOR is unset; otherwise prints plain ASCII so pipes/CI stay
 // clean.
 
+import { getPalette } from './palettes';
+
 // ANSI Shadow letterform for "dgmo" (6 rows) + tagline.
 const ART = [
   '██████╗  ██████╗ ███╗   ███╗ ██████╗ ',
@@ -23,12 +25,24 @@ const ART = [
 
 const TAGLINE = 'diagrams as code';
 
-// Gradient stops sampled from slate (light): blue → teal → cyan.
-const STOPS: Array<[number, number, number]> = [
-  [0x3b, 0x6e, 0xa5], // corporate blue
-  [0x3a, 0x91, 0x88], // teal
-  [0x4f, 0x96, 0xc4], // steel cyan
-];
+// Gradient stops, pulled by name from the live slate palette (light) so the
+// wordmark tracks any palette edit instead of drifting from a hardcoded copy.
+// blue → teal → green → amber: a vivid sweep across the categorical hues.
+const GRADIENT_COLOR_NAMES = ['blue', 'teal', 'green', 'orange'] as const;
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '');
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+}
+
+const STOPS: Array<[number, number, number]> = (() => {
+  const colors = getPalette('slate').light.colors;
+  return GRADIENT_COLOR_NAMES.map((name) => hexToRgb(colors[name]));
+})();
 
 function lerp(a: number, b: number, t: number): number {
   return Math.round(a + (b - a) * t);

--- a/src/cli-banner.ts
+++ b/src/cli-banner.ts
@@ -1,0 +1,93 @@
+// ============================================================
+// CLI Banner — colorful ASCII logo for `dgmo`
+// ============================================================
+//
+// Rendered as the header of `dgmo --help` and at the end of the
+// install/init flows. Uses a horizontal true-color (24-bit) gradient
+// sampled from the default `slate` palette (corporate blue → teal →
+// steel cyan) so the wordmark matches the brand.
+//
+// Honors the same guards as `dgmo cat`: color only when stdout is a TTY
+// and NO_COLOR is unset; otherwise prints plain ASCII so pipes/CI stay
+// clean.
+
+// ANSI Shadow letterform for "dgmo" (6 rows) + tagline.
+const ART = [
+  '██████╗  ██████╗ ███╗   ███╗ ██████╗ ',
+  '██╔══██╗██╔════╝ ████╗ ████║██╔═══██╗',
+  '██║  ██║██║  ███╗██╔████╔██║██║   ██║',
+  '██║  ██║██║   ██║██║╚██╔╝██║██║   ██║',
+  '██████╔╝╚██████╔╝██║ ╚═╝ ██║╚██████╔╝',
+  '╚═════╝  ╚═════╝ ╚═╝     ╚═╝ ╚═════╝ ',
+];
+
+const TAGLINE = 'diagrams as code';
+
+// Gradient stops sampled from slate (light): blue → teal → cyan.
+const STOPS: Array<[number, number, number]> = [
+  [0x3b, 0x6e, 0xa5], // corporate blue
+  [0x3a, 0x91, 0x88], // teal
+  [0x4f, 0x96, 0xc4], // steel cyan
+];
+
+function lerp(a: number, b: number, t: number): number {
+  return Math.round(a + (b - a) * t);
+}
+
+/** Interpolate the multi-stop gradient at position t ∈ [0, 1]. */
+function gradientAt(t: number): [number, number, number] {
+  const clamped = Math.max(0, Math.min(1, t));
+  const span = STOPS.length - 1;
+  const scaled = clamped * span;
+  const i = Math.min(span - 1, Math.floor(scaled));
+  const local = scaled - i;
+  const [r1, g1, b1] = STOPS[i]!;
+  const [r2, g2, b2] = STOPS[i + 1]!;
+  return [lerp(r1, r2, local), lerp(g1, g2, local), lerp(b1, b2, local)];
+}
+
+function fg(r: number, g: number, b: number): string {
+  return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+const RESET = '\x1b[0m';
+
+export interface BannerOptions {
+  /** Force-disable color regardless of TTY (default honors stdout TTY + NO_COLOR). */
+  color?: boolean;
+}
+
+/**
+ * Build the dgmo banner string. Colorized with a horizontal gradient when
+ * `color` is true; otherwise returns plain ASCII.
+ */
+export function renderBanner(opts: BannerOptions = {}): string {
+  const useColor =
+    opts.color ?? (process.stdout.isTTY === true && !process.env['NO_COLOR']);
+
+  const width = Math.max(...ART.map((line) => line.length));
+
+  const lines = ART.map((line) => {
+    if (!useColor) return line;
+    let out = '';
+    for (let col = 0; col < line.length; col++) {
+      const ch = line[col];
+      // Don't paint spaces — keeps escape sequences minimal.
+      if (ch === ' ') {
+        out += ch;
+        continue;
+      }
+      const [r, g, b] = gradientAt(col / (width - 1));
+      out += fg(r, g, b) + ch;
+    }
+    return out + RESET;
+  });
+
+  // Right-align the tagline under the wordmark, muted.
+  const pad = Math.max(0, width - TAGLINE.length);
+  const tagline = useColor
+    ? `${' '.repeat(pad)}\x1b[2;3m${TAGLINE}${RESET}`
+    : `${' '.repeat(pad)}${TAGLINE}`;
+
+  return ['', ...lines, tagline, ''].join('\n');
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import {
   migrateFile,
 } from './migrate';
 import { migrateEmbedded } from './migrate/embedded';
+import { renderBanner } from './cli-banner';
 
 // Derived from the palette registry so new palettes are auto-included.
 const PALETTES = getAvailablePalettes().map((p) => p.id);
@@ -464,6 +465,7 @@ For architecture diagrams, sequence diagrams, flowcharts, and charts, use the \`
 `;
 
 function printHelp(): void {
+  console.log(renderBanner());
   console.log(`Usage: dgmo <input> [options]
        cat input.dgmo | dgmo [options]
        dgmo cat <file>          Display file with syntax highlighting
@@ -648,10 +650,12 @@ function svgToPng(svg: string, background?: string): Buffer {
 }
 
 function noInput(): never {
+  console.error(renderBanner());
   const samplePath = resolve('sample.dgmo');
   if (existsSync(samplePath)) {
     console.error('Error: No input file specified');
     console.error(`Try: dgmo ${basename(samplePath)}`);
+    console.error('Run dgmo --help for all options.');
     process.exit(1);
   }
   writeFileSync(
@@ -923,6 +927,15 @@ async function main(): Promise<void> {
     const tokens = highlightDgmo(catContent);
     process.stdout.write(renderAnsi(tokens, useColor));
     return;
+  }
+
+  if (
+    opts.installClaudeCodeIntegration ||
+    opts.installClaudeSkill ||
+    opts.installCodexIntegration ||
+    opts.installClaudeDesktopIntegration
+  ) {
+    console.log(renderBanner());
   }
 
   if (opts.installClaudeCodeIntegration) {


### PR DESCRIPTION
## What

Adds a colorful ANSI Shadow `dgmo` wordmark with a horizontal true-color gradient, shown on:
- `dgmo --help` (header)
- bare `dgmo` / first-run init flow
- the `--install-*` integration flows

## How

- New `src/cli-banner.ts` builds the banner. Gradient stops are pulled **by name** from the live slate palette (`blue → teal → green → orange` via `getPalette('slate').light.colors`), so the logo tracks any palette edit instead of drifting from a hardcoded copy.
- Color is emitted only when `stdout.isTTY && !NO_COLOR` — otherwise plain ASCII, matching the existing `dgmo cat` color guard. Pipes/CI stay clean.

## Validate

```bash
node dist/cli.cjs --help          # gradient banner in a TTY
node dist/cli.cjs --help | cat    # plain ASCII when piped
NO_COLOR=1 node dist/cli.cjs --help  # plain fallback
```

`pnpm typecheck` + `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)