### PR TITLE
One-step AI install: single binary + zero-prompt auto-detect

### DIFF
--- a/.claude/commands/dgmo.md
+++ b/.claude/commands/dgmo.md
@@ -18,37 +18,15 @@ If the MCP tools are **not** available, run the setup flow below — do not ask 
 which dgmo || npm install -g @diagrammo/dgmo
 ```
 
-### Step 2 — Install the MCP server (if missing)
+### Step 2 — Run the one-step installer
 
 ```bash
-which dgmo-mcp || npm install -g @diagrammo/dgmo-mcp
+dgmo install claude-code
 ```
 
-### Step 3 — Configure the MCP server
+That single command writes this skill, configures the MCP server in `~/.claude/settings.json` (entry: `{ "command": "dgmo", "args": ["mcp"] }`), and ensures the server is available — no prompts, no separate `dgmo-mcp` package to install. (Use `--scope project` to write `.mcp.json` in the current directory instead of the global settings.)
 
-Ask the user:
-
-> "Where should I configure the MCP server?
-> 1) This project only — write `.mcp.json` here [default]
-> 2) Globally — add to `~/.claude/settings.json` (works in all projects)"
-
-**Option 1 (default):** Create or update `.mcp.json` in the current working directory:
-
-```json
-{
-  "mcpServers": {
-    "dgmo": {
-      "command": "dgmo-mcp"
-    }
-  }
-}
-```
-
-If `.mcp.json` already exists and has other servers, merge the `dgmo` entry in — do not overwrite the file.
-
-**Option 2 (global):** Add the `dgmo` entry to the `mcpServers` object in `~/.claude/settings.json`. Read the file first and merge — do not overwrite other keys.
-
-### Step 4 — Prompt restart
+### Step 3 — Prompt restart
 
 Tell the user:
 
@@ -56,7 +34,7 @@ Tell the user:
 
 Then proceed with the user's original request using CLI fallback (see "Other output options" below).
 
-> **Note for future users:** To set up in one step from the terminal before starting a Claude Code session, run `dgmo install claude-code`. It handles everything: installs `@diagrammo/dgmo-mcp`, writes the skill, and configures the MCP server.
+> **One-step from a fresh machine:** `dgmo install` with no target auto-detects and sets up every AI assistant you have (Claude Code, Codex, Claude Desktop, Cursor, Windsurf, Copilot) at once.
 
 ## Project Awareness
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,18 @@ jobs:
           for i in 1 2 3 4 5 6; do
             if curl -sIfL "$URL" >/dev/null; then
               SHA=$(curl -sL "$URL" | shasum -a 256 | cut -d' ' -f1)
+              # Pin the formula to the current latest dgmo-mcp so a dgmo release
+              # ships a tested CLI+server pair (`brew upgrade dgmo` upgrades both).
+              MCP_VERSION=$(npm view @diagrammo/dgmo-mcp version)
+              MCP_URL="https://registry.npmjs.org/@diagrammo/dgmo-mcp/-/dgmo-mcp-${MCP_VERSION}.tgz"
+              MCP_SHA=$(curl -sL "$MCP_URL" | shasum -a 256 | cut -d' ' -f1)
               echo "VERSION=$VERSION" >> "$GITHUB_ENV"
               echo "URL=$URL" >> "$GITHUB_ENV"
               echo "SHA=$SHA" >> "$GITHUB_ENV"
-              echo "✓ tarball available, sha=$SHA"
+              echo "MCP_VERSION=$MCP_VERSION" >> "$GITHUB_ENV"
+              echo "MCP_URL=$MCP_URL" >> "$GITHUB_ENV"
+              echo "MCP_SHA=$MCP_SHA" >> "$GITHUB_ENV"
+              echo "✓ tarball available, sha=$SHA, dgmo-mcp=$MCP_VERSION"
               exit 0
             fi
             echo "waiting for npm tarball ($i/6)..."
@@ -97,8 +105,12 @@ jobs:
       - name: Update formula and open PR
         run: |
           cd homebrew-dgmo
-          sed -i "s|url \".*\"|url \"$URL\"|" Formula/dgmo.rb
-          sed -i "s|sha256 \".*\"|sha256 \"$SHA\"|" Formula/dgmo.rb
+          # Anchor by indentation: the top-level dgmo url/sha256 are 2-space
+          # indented; the dgmo-mcp `resource` block's are 4-space indented.
+          sed -i "s|^  url \".*\"|  url \"$URL\"|" Formula/dgmo.rb
+          sed -i "s|^  sha256 \".*\"|  sha256 \"$SHA\"|" Formula/dgmo.rb
+          sed -i "s|^    url \".*\"|    url \"$MCP_URL\"|" Formula/dgmo.rb
+          sed -i "s|^    sha256 \".*\"|    sha256 \"$MCP_SHA\"|" Formula/dgmo.rb
           if git diff --quiet; then
             echo "::warning::Formula already at $VERSION — skipping PR"
             exit 0
@@ -108,7 +120,7 @@ jobs:
           BRANCH="bump-dgmo-${VERSION}"
           git checkout -b "$BRANCH"
           git add Formula/dgmo.rb
-          git commit -m "Bump dgmo to ${VERSION}"
+          git commit -m "Bump dgmo to ${VERSION} (dgmo-mcp ${MCP_VERSION})"
           git push origin "$BRANCH"
           gh pr create \
             --title "Bump dgmo to ${VERSION}" \

--- a/README.md
+++ b/README.md
@@ -110,7 +110,13 @@ Using a docs framework? First-class plugins wrap all of this:
 
 ## Use it from your AI tool
 
-There's an MCP server ([`@diagrammo/dgmo-mcp`](https://www.npmjs.com/package/@diagrammo/dgmo-mcp)) so Claude, Cursor, and other agents can author and render DGMO directly. Setup: **[diagrammo.app/ai](https://diagrammo.app/ai)**.
+Claude, Cursor, Codex, and other agents can author and render DGMO directly. One command sets up every assistant you have — no second package, no prompts:
+
+```bash
+dgmo install
+```
+
+It auto-detects Claude Code, Codex, Claude Desktop, Cursor, Windsurf, and Copilot and wires each one to the bundled MCP server. More: **[diagrammo.app/ai](https://diagrammo.app/ai)**.
 
 ## Chart types
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -25,7 +25,10 @@ dgmo install --dry-run                # preview every change, write nothing
 
 For Claude Code this copies the `/dgmo` skill into `~/.claude/commands/` (full dgmo context — all chart types, CLI flags, workflow, and tips) and adds the MCP server to `~/.claude/settings.json`. Restart the assistant afterward.
 
-**Keeping it current:** the skill files and the MCP server (a separately-versioned package) are *not* refreshed by a plain `dgmo` upgrade. After upgrading the CLI, re-run `dgmo install` — it overwrites the skill files and upgrades the server to the latest. (Or set `DGMO_MCP_LATEST=1` in the environment to make `dgmo mcp` always fetch the newest server at launch, at the cost of a network round-trip on start.)
+**Keeping it current:**
+- **Homebrew** bundles the MCP server, so `brew upgrade dgmo` upgrades the CLI *and* the server together. Re-run `dgmo install` afterward only to refresh the **skill files** (those are copies in your home dir).
+- **npm global**: a plain `dgmo` upgrade doesn't touch the server or skill copies — re-run `dgmo install`, which overwrites the skills and upgrades the server to the latest.
+- Either way, `DGMO_MCP_LATEST=1` in the environment makes `dgmo mcp` always fetch the newest server at launch (network round-trip on start), so it's never stale.
 
 ---
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -484,15 +484,15 @@ DGMO ships context files for popular AI coding tools, included in the npm packag
 | `.cursorrules` | Cursor | Auto-loaded when present in project root |
 | `.windsurfrules` | Windsurf | Auto-loaded when present in project root (byte-identical to `.cursorrules`) |
 
-The easiest way to drop these into a project is `dgmo install` — it writes the right file for each tool it detects:
+The easiest way to set these up is `dgmo install` — it does the right thing per tool:
 
 ```bash
-dgmo install cursor      # writes ./.cursorrules
-dgmo install windsurf    # writes ./.windsurfrules
-dgmo install copilot     # writes ./.github/copilot-instructions.md
+dgmo install cursor      # wires MCP (~/.cursor/mcp.json) + drops .cursorrules
+dgmo install windsurf    # wires MCP (~/.codeium/windsurf/mcp_config.json) + .windsurfrules
+dgmo install copilot     # writes ./.github/copilot-instructions.md (Copilot has no MCP)
 ```
 
-(`dgmo install` with no target also writes Copilot's file automatically when the current repo has a `.github` directory.) To copy by hand instead:
+Cursor and Windsurf speak MCP, so `dgmo install` gives them the full render/share tools (pointed at `dgmo mcp`), plus the inline rules file. Copilot is guidance-only. `dgmo install` with no target also writes Copilot's file automatically when the current repo has a `.github` directory. To set the context files up by hand instead:
 
 ```bash
 # From node_modules (if installed as a dependency)

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -4,38 +4,45 @@ Use AI coding tools to generate `.dgmo` diagrams. This guide covers Claude Code,
 
 ---
 
-## MCP Server (recommended for Claude)
+## One-step setup (recommended)
 
-`@diagrammo/dgmo-mcp` provides an MCP server that gives Claude the ability to render, share, and look up DGMO diagrams directly — no file management needed.
+Install the `dgmo` CLI, then run one command:
 
-**5 tools:** `render_diagram`, `share_diagram`, `open_in_app`, `list_chart_types`, `get_language_reference`
+```bash
+brew install diagrammo/dgmo/dgmo   # or: npm install -g @diagrammo/dgmo
+dgmo install                       # auto-detects every AI assistant you have
+```
 
-Add to `~/.claude/settings.json` (global) or `.claude/settings.local.json` (project):
+`dgmo install` with **no target** scans for Claude Code, Codex, Claude Desktop, Cursor, Windsurf, and Copilot, then configures each one non-interactively — no prompts, no second package to install. The only binary you ever need is `dgmo`; it provides the MCP server through its own `dgmo mcp` subcommand.
+
+Target a single assistant, or pick a scope, when you want to:
+
+```bash
+dgmo install claude-code              # just one surface
+dgmo install codex --scope project    # write config into the current repo
+dgmo install --dry-run                # preview every change, write nothing
+```
+
+For Claude Code this copies the `/dgmo` skill into `~/.claude/commands/` (full dgmo context — all chart types, CLI flags, workflow, and tips) and adds the MCP server to `~/.claude/settings.json`. Restart the assistant afterward.
+
+---
+
+## Manual MCP configuration
+
+`dgmo install` is the easy path. To wire the MCP server by hand, point any MCP client at the `dgmo` binary's `mcp` subcommand:
 
 ```json
 {
   "mcpServers": {
     "dgmo": {
-      "command": "npx",
-      "args": ["-y", "@diagrammo/dgmo-mcp"]
+      "command": "dgmo",
+      "args": ["mcp"]
     }
   }
 }
 ```
 
-See `dgmo-mcp/README.md` for full configuration options.
-
----
-
-## Claude Code — Skill + MCP server
-
-Installs the `/dgmo` slash command (full dgmo context — all chart types, CLI flags, workflow, and tips) and configures the dgmo MCP server.
-
-```bash
-dgmo install claude-code
-```
-
-This copies a skill file into `~/.claude/commands/` (making `/dgmo` available in every Claude Code session) and wires up the MCP server. The MCP step is skippable in the prompts if you only want the skill.
+**5 tools:** `render_diagram`, `share_diagram`, `open_in_app`, `list_chart_types`, `get_language_reference`. `dgmo mcp` execs the installed server, or fetches it on demand via `npx` if it isn't installed yet — so no separate `dgmo-mcp` step is required. (If you'd rather not install the CLI at all, `{ "command": "npx", "args": ["-y", "@diagrammo/dgmo-mcp"] }` still works.) See `dgmo-mcp/README.md` for full options.
 
 ---
 
@@ -477,7 +484,15 @@ DGMO ships context files for popular AI coding tools, included in the npm packag
 | `.cursorrules` | Cursor | Auto-loaded when present in project root |
 | `.windsurfrules` | Windsurf | Auto-loaded when present in project root (byte-identical to `.cursorrules`) |
 
-Copy the relevant file into your project root:
+The easiest way to drop these into a project is `dgmo install` — it writes the right file for each tool it detects:
+
+```bash
+dgmo install cursor      # writes ./.cursorrules
+dgmo install windsurf    # writes ./.windsurfrules
+dgmo install copilot     # writes ./.github/copilot-instructions.md
+```
+
+(`dgmo install` with no target also writes Copilot's file automatically when the current repo has a `.github` directory.) To copy by hand instead:
 
 ```bash
 # From node_modules (if installed as a dependency)

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -25,6 +25,8 @@ dgmo install --dry-run                # preview every change, write nothing
 
 For Claude Code this copies the `/dgmo` skill into `~/.claude/commands/` (full dgmo context — all chart types, CLI flags, workflow, and tips) and adds the MCP server to `~/.claude/settings.json`. Restart the assistant afterward.
 
+**Keeping it current:** the skill files and the MCP server (a separately-versioned package) are *not* refreshed by a plain `dgmo` upgrade. After upgrading the CLI, re-run `dgmo install` — it overwrites the skill files and upgrades the server to the latest. (Or set `DGMO_MCP_LATEST=1` in the environment to make `dgmo mcp` always fetch the newest server at launch, at the cost of a network round-trip on start.)
+
 ---
 
 ## Manual MCP configuration

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -573,9 +573,11 @@ async function runOneInstall(
     case 'claude-desktop':
       return installClaudeDesktop(opts);
     case 'cursor':
+      return installCursor(opts);
     case 'windsurf':
+      return installWindsurf(opts);
     case 'copilot':
-      return installEditorRules(target, opts);
+      return installCopilot(opts);
   }
 }
 
@@ -710,27 +712,47 @@ async function installClaudeDesktop(opts: InstallOpts): Promise<void> {
   upsertJsonMcp(opts, claudeDesktopConfigPath());
 }
 
-// Cursor / Windsurf / Copilot are non-MCP: they read a project-root context
-// file. We ship those files in the package and copy them into the cwd. This
-// closes the former manual-copy gap for those editors.
-function installEditorRules(
-  kind: 'cursor' | 'windsurf' | 'copilot',
-  opts: InstallOpts
-): void {
-  const map = {
-    cursor: { src: ['.cursorrules'], dest: ['.cursorrules'] },
-    windsurf: { src: ['.windsurfrules'], dest: ['.windsurfrules'] },
-    copilot: {
-      src: ['.github', 'copilot-instructions.md'],
-      dest: ['.github', 'copilot-instructions.md'],
-    },
-  } as const;
-  const { src, dest } = map[kind];
+// Cursor speaks MCP via ~/.cursor/mcp.json (user) or .cursor/mcp.json (project),
+// using the same { mcpServers } schema as Claude — so it gets the full tools,
+// not just syntax guidance. We also drop the shipped .cursorrules so the model
+// has inline context without a tool round-trip.
+function installCursor(opts: InstallOpts): void {
+  ensureDgmoMcp(opts);
+  const path =
+    opts.scope === 'project'
+      ? join(process.cwd(), '.cursor', 'mcp.json')
+      : join(homedir(), '.cursor', 'mcp.json');
+  upsertJsonMcp(opts, path);
   writeOut(
     opts,
-    join(process.cwd(), ...dest),
-    readPackagedFile(...src),
-    `${kind} context → ${join(...dest)}`
+    join(process.cwd(), '.cursorrules'),
+    readPackagedFile('.cursorrules'),
+    'Cursor rules → .cursorrules'
+  );
+}
+
+// Windsurf (Codeium) reads MCP from ~/.codeium/windsurf/mcp_config.json.
+function installWindsurf(opts: InstallOpts): void {
+  ensureDgmoMcp(opts);
+  upsertJsonMcp(
+    opts,
+    join(homedir(), '.codeium', 'windsurf', 'mcp_config.json')
+  );
+  writeOut(
+    opts,
+    join(process.cwd(), '.windsurfrules'),
+    readPackagedFile('.windsurfrules'),
+    'Windsurf rules → .windsurfrules'
+  );
+}
+
+// Copilot has no MCP path — ship the project-root instructions file it auto-loads.
+function installCopilot(opts: InstallOpts): void {
+  writeOut(
+    opts,
+    join(process.cwd(), '.github', 'copilot-instructions.md'),
+    readPackagedFile('.github', 'copilot-instructions.md'),
+    'Copilot context → .github/copilot-instructions.md'
   );
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -487,10 +487,27 @@ function claudeDesktopConfigPath(): string {
 // has no cold-start. Not required for correctness — `dgmo mcp` falls back to
 // npx — so any failure is a note, not an error. Memoized: in auto mode we set
 // up several surfaces in one run and only need to check once.
+// True when this CLI is running from a Homebrew install (its files live under
+// a Cellar prefix). Homebrew owns the MCP server in that case.
+function isHomebrewManaged(): boolean {
+  return PKG_ROOT.includes('/Cellar/') || PKG_ROOT.includes('/homebrew/');
+}
+
 let mcpEnsured = false;
 function ensureDgmoMcp(opts: InstallOpts): void {
   if (mcpEnsured) return;
   mcpEnsured = true;
+  // Homebrew vendors and upgrades the MCP server alongside the CLI (the formula
+  // installs `dgmo-mcp` into the same prefix). Don't npm-install a second global
+  // copy that would shadow brew's — `brew upgrade dgmo` keeps it current.
+  if (isHomebrewManaged()) {
+    console.log(
+      commandExists('dgmo-mcp')
+        ? '✓ MCP server managed by Homebrew (upgrades with `brew upgrade dgmo`)'
+        : '  MCP server not found — it will be fetched on first use via npx.'
+    );
+    return;
+  }
   if (opts.dryRun) {
     console.log('  [dry-run] would install/upgrade @diagrammo/dgmo-mcp@latest');
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-console */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { homedir, platform } from 'node:os';
-import { resolve, join, basename, extname } from 'node:path';
-import { createInterface } from 'node:readline';
+import { resolve, join, dirname, basename, extname } from 'node:path';
 import { Resvg } from '@resvg/resvg-js';
 import { render } from './render';
 import {
@@ -74,8 +73,10 @@ function printHelp(): void {
 Commands:
   dgmo share <input>       Print a shareable diagrammo.app URL (copies to clipboard)
   dgmo types               List all supported chart types
-  dgmo install [target]    Set up an AI assistant integration
-                           (claude-code, codex, claude-desktop)
+  dgmo install [target]    Set up AI assistants (auto-detects all if no target).
+                           Targets: claude-code, codex, claude-desktop,
+                           cursor, windsurf, copilot. --scope user|project
+  dgmo mcp                 Run the MCP server (invoked by AI client configs)
   dgmo map-search <query>  Find the map place token (city or IATA code)
 
 Render options:
@@ -227,20 +228,6 @@ function noInput(): never {
     'Edit sample.dgmo to make it your own, or run dgmo --help for all options.'
   );
   process.exit(0);
-}
-
-// Shared interactive prompt helper used by the `install` subcommands.
-function ask(prompt: string): Promise<string> {
-  return new Promise((resolve) => {
-    const rl = createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-    rl.question(prompt, (answer) => {
-      rl.close();
-      resolve(answer);
-    });
-  });
 }
 
 // Best-effort clipboard copy across platforms. Returns true on success.
@@ -411,410 +398,340 @@ async function runShareCommand(args: string[]): Promise<void> {
   }
 }
 
-// `dgmo install [target]` — consolidates the former four `--install-*` flags
-// into one subcommand namespace. Valid targets:
-//   claude-code     skill + MCP server for Claude Code (MCP step is skippable)
-//   codex           skill + MCP server for the Codex CLI
-//   claude-desktop  MCP server for the Claude Desktop app
-async function runInstallCommand(args: string[]): Promise<void> {
-  const targets = ['claude-code', 'codex', 'claude-desktop'];
-  let target = args.find((a) => !a.startsWith('-'));
+// Single source of truth for how every AI client launches the MCP server: the
+// `dgmo` binary the user already has, plus the `mcp` subcommand. No generated
+// config ever references a separate `dgmo-mcp` command — the user installs one
+// binary and that's it. (The server itself still lives in the
+// @diagrammo/dgmo-mcp package, which depends on this library; `dgmo mcp` locates
+// and execs it, so there's no dependency cycle and no extra deps bundled here.)
+const MCP_LAUNCH = { command: 'dgmo', args: ['mcp'] } as const;
 
-  if (!target) {
-    console.log(renderBanner());
-    console.log('Which AI assistant integration would you like to set up?');
-    console.log(
-      '  1) claude-code     — /dgmo skill + MCP server (recommended)'
-    );
-    console.log('  2) codex           — Codex CLI skill + MCP server');
-    console.log('  3) claude-desktop  — Claude Desktop MCP server');
-    const ans = (await ask('\nChoice [1]: ')).trim();
-    target = (
-      {
-        '': 'claude-code',
-        '1': 'claude-code',
-        '2': 'codex',
-        '3': 'claude-desktop',
-      } as Record<string, string>
-    )[ans];
-    if (!target) {
-      console.error(`Unrecognized choice "${ans}".`);
-      process.exit(1);
-    }
-  } else if (!targets.includes(target)) {
-    console.error(`Error: Unknown install target "${target}".`);
-    console.error(`Valid targets: ${targets.join(', ')}`);
-    process.exit(1);
-  } else {
-    console.log(renderBanner());
-  }
+const INSTALL_TARGETS = [
+  'claude-code',
+  'codex',
+  'claude-desktop',
+  'cursor',
+  'windsurf',
+  'copilot',
+] as const;
+type InstallTarget = (typeof INSTALL_TARGETS)[number];
 
-  if (target === 'claude-code') {
-    await installClaudeCode();
-  } else if (target === 'codex') {
-    await installCodex();
-  } else {
-    await installClaudeDesktop();
-  }
+interface InstallOpts {
+  scope: 'user' | 'project';
+  dryRun: boolean;
 }
 
-async function installClaudeCode(): Promise<void> {
-  const claudeDir = join(homedir(), '.claude');
-  if (!existsSync(claudeDir)) {
-    console.error('~/.claude directory not found.');
-    console.error('Install Claude Code first: https://claude.ai/code');
-    process.exit(1);
-  }
-
-  // --- Step 1: Install skill ---
-  const commandsDir = join(claudeDir, 'commands');
-  const skillPath = join(commandsDir, 'dgmo.md');
-  const skillExists = existsSync(skillPath);
-  let installSkill = true;
-  if (skillExists) {
-    const ans = await ask(
-      '~/.claude/commands/dgmo.md already exists. Overwrite? [y/N] '
-    );
-    installSkill = ans.toLowerCase() === 'y' || ans.toLowerCase() === 'yes';
-  }
-  if (installSkill) {
-    if (!existsSync(commandsDir)) mkdirSync(commandsDir, { recursive: true });
-    writeFileSync(skillPath, readClaudeSkill(), 'utf-8');
-    console.log('✓ Skill installed: ~/.claude/commands/dgmo.md');
-  } else {
-    console.log('  Skipped skill install.');
-  }
-
-  // --- Step 2: Check / install dgmo-mcp binary ---
-  let dgmoMcpInstalled = false;
-  try {
-    execSync('which dgmo-mcp', { stdio: 'pipe' });
-    dgmoMcpInstalled = true;
-  } catch {
-    /* not found */
-  }
-  if (!dgmoMcpInstalled) {
-    const ans = await ask(
-      '\ndgmo-mcp not found. Install @diagrammo/dgmo-mcp globally now? [Y/n] '
-    );
-    const yes =
-      ans === '' || ans.toLowerCase() === 'y' || ans.toLowerCase() === 'yes';
-    if (yes) {
-      console.log('Installing @diagrammo/dgmo-mcp...');
-      execSync('npm install -g @diagrammo/dgmo-mcp', { stdio: 'inherit' });
-      console.log('✓ @diagrammo/dgmo-mcp installed');
-    } else {
-      console.log(
-        '  Skipped. Install later with: npm install -g @diagrammo/dgmo-mcp'
-      );
-    }
-  } else {
-    console.log('✓ dgmo-mcp already installed');
-  }
-
-  // --- Step 3: Configure MCP server ---
-  console.log('\nWhere should the MCP server be configured?');
-  console.log('  1) This project only — write .mcp.json here [default]');
-  console.log(
-    '  2) Globally — add to ~/.claude/settings.json (works in all projects)'
-  );
-  const scopeAns = await ask('\nChoice [1]: ');
-  const useGlobal = scopeAns.trim() === '2';
-  const mcpEntry = { command: 'dgmo-mcp' };
-
-  if (useGlobal) {
-    const settingsPath = join(claudeDir, 'settings.json');
-    let settings: Record<string, unknown> = {};
-    if (existsSync(settingsPath)) {
-      try {
-        settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-      } catch {
-        /* use empty */
-      }
-    }
-    const mcpServers =
-      (settings['mcpServers'] as Record<string, unknown> | undefined) ?? {};
-    mcpServers['dgmo'] = mcpEntry;
-    settings['mcpServers'] = mcpServers;
-    writeFileSync(
-      settingsPath,
-      JSON.stringify(settings, null, 2) + '\n',
-      'utf-8'
-    );
-    console.log('✓ MCP server added to ~/.claude/settings.json');
-  } else {
-    const mcpPath = join(process.cwd(), '.mcp.json');
-    let mcp: Record<string, unknown> = {};
-    if (existsSync(mcpPath)) {
-      try {
-        mcp = JSON.parse(readFileSync(mcpPath, 'utf-8'));
-      } catch {
-        /* use empty */
-      }
-    }
-    const mcpServers =
-      (mcp['mcpServers'] as Record<string, unknown> | undefined) ?? {};
-    mcpServers['dgmo'] = mcpEntry;
-    mcp['mcpServers'] = mcpServers;
-    writeFileSync(mcpPath, JSON.stringify(mcp, null, 2) + '\n', 'utf-8');
-    console.log(`✓ MCP server configured: ${join(process.cwd(), '.mcp.json')}`);
-  }
-
-  console.log('\nRestart Claude Code to activate the MCP server.');
-  console.log('Then type /dgmo in any session to start creating diagrams.');
-}
-
-async function installCodex(): Promise<void> {
-  // Validate Codex CLI is installed
-  try {
-    execSync('which codex', { stdio: 'pipe' });
-  } catch {
+// `dgmo mcp` — run the MCP server. This is what AI client configs invoke. It
+// execs the installed `dgmo-mcp` binary if present, otherwise fetches and runs
+// it on demand via npx so a config pointing at `dgmo mcp` works even before the
+// server package has been installed. stdio is inherited so the stdio MCP
+// transport is fully transparent.
+function runMcpCommand(args: string[]): never {
+  const onWin = process.platform === 'win32';
+  const run = (cmd: string, cmdArgs: string[]) =>
+    spawnSync(cmd, cmdArgs, { stdio: 'inherit', shell: onWin });
+  const res = commandExists('dgmo-mcp')
+    ? run('dgmo-mcp', args)
+    : run('npx', ['-y', '@diagrammo/dgmo-mcp', ...args]);
+  if (res.error) {
     console.error(
-      'codex not found. Install Codex CLI first: https://openai.com/codex'
+      'Could not launch the dgmo MCP server. Install it with: npm install -g @diagrammo/dgmo-mcp'
     );
     process.exit(1);
   }
-
-  // Check / install dgmo-mcp binary
-  let dgmoMcpInstalled = false;
-  try {
-    execSync('which dgmo-mcp', { stdio: 'pipe' });
-    dgmoMcpInstalled = true;
-  } catch {
-    /* not found */
-  }
-  if (!dgmoMcpInstalled) {
-    const ans = await ask(
-      '\ndgmo-mcp not found. Install @diagrammo/dgmo-mcp globally now? [Y/n] '
-    );
-    const yes =
-      ans === '' || ans.toLowerCase() === 'y' || ans.toLowerCase() === 'yes';
-    if (yes) {
-      console.log('Installing @diagrammo/dgmo-mcp...');
-      try {
-        execSync('npm install -g @diagrammo/dgmo-mcp', { stdio: 'inherit' });
-        console.log('✓ @diagrammo/dgmo-mcp installed');
-      } catch {
-        console.error('Error: Failed to install @diagrammo/dgmo-mcp.');
-        console.error('Try manually: npm install -g @diagrammo/dgmo-mcp');
-      }
-    } else {
-      console.log(
-        '  Skipped. Install later with: npm install -g @diagrammo/dgmo-mcp'
-      );
-    }
-  } else {
-    console.log('✓ dgmo-mcp already installed');
-  }
-
-  // Configure MCP server
-  console.log('\nWhere should the MCP server be configured?');
-  console.log(
-    '  1) This project only — write .codex/config.toml here [default]'
-  );
-  console.log(
-    '  2) Globally — add to ~/.codex/config.toml (works in all projects)'
-  );
-  const scopeAns = await ask('\nChoice [1]: ');
-  if (
-    scopeAns.trim() !== '' &&
-    scopeAns.trim() !== '1' &&
-    scopeAns.trim() !== '2'
-  ) {
-    console.log(
-      `  Unrecognized input "${scopeAns.trim()}", defaulting to option 1.`
-    );
-  }
-  const useGlobal = scopeAns.trim() === '2';
-  const tomlEntry = '[mcp_servers.dgmo]\ncommand = "dgmo-mcp"\n';
-
-  if (useGlobal) {
-    const configPath = join(homedir(), '.codex', 'config.toml');
-    mkdirSync(join(homedir(), '.codex'), { recursive: true });
-    const existing = existsSync(configPath)
-      ? readFileSync(configPath, 'utf-8')
-      : '';
-    if (existing.includes('[mcp_servers.dgmo]')) {
-      console.log('✓ MCP server already configured in ~/.codex/config.toml');
-    } else {
-      const separator = existing.length > 0 ? '\n' : '';
-      writeFileSync(configPath, existing + separator + tomlEntry, 'utf-8');
-      console.log('✓ MCP server added to ~/.codex/config.toml');
-    }
-  } else {
-    const codexDir = join(process.cwd(), '.codex');
-    const configPath = join(codexDir, 'config.toml');
-    mkdirSync(codexDir, { recursive: true });
-    const existing = existsSync(configPath)
-      ? readFileSync(configPath, 'utf-8')
-      : '';
-    if (existing.includes('[mcp_servers.dgmo]')) {
-      console.log(`✓ MCP server already configured in .codex/config.toml`);
-    } else {
-      const separator = existing.length > 0 ? '\n' : '';
-      writeFileSync(configPath, existing + separator + tomlEntry, 'utf-8');
-      console.log(`✓ MCP server configured: ${configPath}`);
-    }
-  }
-
-  // Install the dgmo-diagramming skill at ~/.codex/skills/dgmo-diagramming/SKILL.md
-  const skillDir = join(homedir(), '.codex', 'skills', 'dgmo-diagramming');
-  const skillPath = join(skillDir, 'SKILL.md');
-  const skillBody = readCodexSkill();
-  if (existsSync(skillPath)) {
-    const existingSkill = readFileSync(skillPath, 'utf-8');
-    if (existingSkill === skillBody) {
-      console.log('✓ dgmo-diagramming skill already up to date');
-    } else {
-      const ans = await ask(
-        '\n~/.codex/skills/dgmo-diagramming/SKILL.md exists. Overwrite? [Y/n] '
-      );
-      const yes =
-        ans === '' || ans.toLowerCase() === 'y' || ans.toLowerCase() === 'yes';
-      if (yes) {
-        writeFileSync(skillPath, skillBody, 'utf-8');
-        console.log(`✓ Skill updated: ${skillPath}`);
-      } else {
-        console.log('  Skipped skill update.');
-      }
-    }
-  } else {
-    mkdirSync(skillDir, { recursive: true });
-    writeFileSync(skillPath, skillBody, 'utf-8');
-    console.log(`✓ Skill installed: ${skillPath}`);
-  }
-
-  // Non-destructive AGENTS.md handling: append a marked note only if AGENTS.md
-  // already exists and doesn't already contain the marker. Never create it.
-  const agentsPath = join(process.cwd(), 'AGENTS.md');
-  if (existsSync(agentsPath)) {
-    const existingAgents = readFileSync(agentsPath, 'utf-8');
-    if (existingAgents.includes(CODEX_AGENTS_NOTE_MARKER)) {
-      console.log('✓ AGENTS.md already mentions dgmo');
-    } else {
-      const separator = existingAgents.endsWith('\n') ? '\n' : '\n\n';
-      writeFileSync(
-        agentsPath,
-        existingAgents + separator + CODEX_AGENTS_NOTE,
-        'utf-8'
-      );
-      console.log(`✓ Appended dgmo note to: ${agentsPath}`);
-    }
-  } else {
-    console.log('  No AGENTS.md found in cwd — skipped (the skill is enough).');
-  }
-
-  console.log('\nRestart Codex to activate the skill and MCP server.');
+  process.exit(res.status ?? 0);
 }
 
-async function installClaudeDesktop(): Promise<void> {
-  // Check / install dgmo-mcp binary
-  let dgmoMcpInstalled = false;
+// Cross-platform "is this command on PATH?" check.
+function commandExists(cmd: string): boolean {
   try {
-    execSync('which dgmo-mcp', { stdio: 'pipe' });
-    dgmoMcpInstalled = true;
+    const probe =
+      process.platform === 'win32' ? `where ${cmd}` : `command -v ${cmd}`;
+    execSync(probe, { stdio: 'pipe' });
+    return true;
   } catch {
-    /* not found */
+    return false;
   }
-  if (!dgmoMcpInstalled) {
-    const ans = await ask(
-      '\ndgmo-mcp not found. Install @diagrammo/dgmo-mcp globally now? [Y/n] '
-    );
-    const yes =
-      ans === '' || ans.toLowerCase() === 'y' || ans.toLowerCase() === 'yes';
-    if (yes) {
-      console.log('Installing @diagrammo/dgmo-mcp...');
-      try {
-        execSync('npm install -g @diagrammo/dgmo-mcp', { stdio: 'inherit' });
-        console.log('✓ @diagrammo/dgmo-mcp installed');
-      } catch {
-        console.error('Error: Failed to install @diagrammo/dgmo-mcp.');
-        console.error('Try manually: npm install -g @diagrammo/dgmo-mcp');
-      }
-    } else {
-      console.log(
-        '  Skipped. Install later with: npm install -g @diagrammo/dgmo-mcp'
-      );
-    }
-  } else {
-    console.log('✓ dgmo-mcp already installed');
-  }
+}
 
-  // Resolve the Claude Desktop config path for the current platform.
-  // macOS and Windows use the documented Claude Desktop paths; Linux
-  // doesn't have a first-party build yet, but community installs follow
-  // the XDG config convention.
+// Claude Desktop config path for the current platform. macOS/Windows use the
+// documented locations; Linux follows the XDG convention community builds use.
+function claudeDesktopConfigPath(): string {
   const os = platform();
-  let configPath: string;
   if (os === 'darwin') {
-    configPath = join(
+    return join(
       homedir(),
       'Library',
       'Application Support',
       'Claude',
       'claude_desktop_config.json'
     );
-  } else if (os === 'win32') {
+  }
+  if (os === 'win32') {
     const appData =
       process.env['APPDATA'] ?? join(homedir(), 'AppData', 'Roaming');
-    configPath = join(appData, 'Claude', 'claude_desktop_config.json');
-  } else {
-    configPath = join(
-      homedir(),
-      '.config',
-      'Claude',
-      'claude_desktop_config.json'
+    return join(appData, 'Claude', 'claude_desktop_config.json');
+  }
+  return join(homedir(), '.config', 'Claude', 'claude_desktop_config.json');
+}
+
+// Best-effort, NON-fatal pre-install of the MCP server so the first tool call
+// has no cold-start. Not required for correctness — `dgmo mcp` falls back to
+// npx — so any failure is a note, not an error. Memoized: in auto mode we set
+// up several surfaces in one run and only need to check once.
+let mcpEnsured = false;
+function ensureDgmoMcp(opts: InstallOpts): void {
+  if (mcpEnsured) return;
+  mcpEnsured = true;
+  if (commandExists('dgmo-mcp')) {
+    console.log('✓ MCP server present');
+    return;
+  }
+  if (opts.dryRun) {
+    console.log('  [dry-run] would install @diagrammo/dgmo-mcp');
+    return;
+  }
+  try {
+    console.log('Installing the MCP server (one-time)…');
+    execSync('npm install -g @diagrammo/dgmo-mcp', { stdio: 'inherit' });
+    console.log('✓ MCP server installed');
+  } catch {
+    console.log(
+      '  Could not pre-install — it will be fetched on first use via npx.'
     );
   }
+}
 
-  // Read existing config (or start fresh). Non-JSON contents are treated
-  // as corruption and we bail — the user needs to resolve it manually so
-  // we don't silently overwrite something they care about.
-  type ClaudeDesktopConfig = {
-    mcpServers?: Record<
-      string,
-      { command: string; args?: string[]; env?: Record<string, string> }
-    >;
-    [key: string]: unknown;
-  };
-  let config: ClaudeDesktopConfig = {};
-  if (existsSync(configPath)) {
-    const raw = readFileSync(configPath, 'utf-8');
+// Write helper that honors --dry-run and creates parent dirs.
+function writeOut(
+  opts: InstallOpts,
+  path: string,
+  content: string,
+  label: string
+): void {
+  if (opts.dryRun) {
+    console.log(`  [dry-run] would write ${label}`);
+    return;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+  console.log(`✓ ${label}`);
+}
+
+// Merge `{ mcpServers: { dgmo: dgmo mcp } }` into a JSON config (Claude Code /
+// Claude Desktop style), preserving any other entries.
+function upsertJsonMcp(opts: InstallOpts, path: string): void {
+  let cfg: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    const raw = readFileSync(path, 'utf-8');
     if (raw.trim().length > 0) {
       try {
-        config = JSON.parse(raw) as ClaudeDesktopConfig;
+        cfg = JSON.parse(raw);
       } catch {
         console.error(
-          `Error: ${configPath} exists but is not valid JSON. Fix it manually and re-run, or remove the file to regenerate.`
+          `Error: ${path} is not valid JSON — fix it and re-run (skipping it for now).`
         );
-        process.exit(1);
-      }
-    }
-  }
-
-  const existingDgmo = config.mcpServers?.['dgmo'];
-  if (existingDgmo?.command === 'dgmo-mcp') {
-    console.log(`✓ dgmo MCP server already configured in ${configPath}`);
-  } else {
-    if (existingDgmo) {
-      const ans = await ask(
-        `\nA "dgmo" entry already exists in ${configPath}. Overwrite? [y/N] `
-      );
-      if (ans.toLowerCase() !== 'y' && ans.toLowerCase() !== 'yes') {
-        console.log('  Skipped.');
         return;
       }
     }
-    config.mcpServers = {
-      ...(config.mcpServers ?? {}),
-      dgmo: { command: 'dgmo-mcp' },
-    };
-    mkdirSync(join(configPath, '..'), { recursive: true });
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
-    console.log(`✓ dgmo MCP server configured: ${configPath}`);
+  }
+  const servers =
+    (cfg['mcpServers'] as Record<string, unknown> | undefined) ?? {};
+  servers['dgmo'] = MCP_LAUNCH;
+  cfg['mcpServers'] = servers;
+  writeOut(opts, path, JSON.stringify(cfg, null, 2) + '\n', `MCP server → ${path}`);
+}
+
+// Which AI surfaces are present on this machine? Drives zero-prompt auto setup.
+function detectSurfaces(): InstallTarget[] {
+  const found: InstallTarget[] = [];
+  if (existsSync(join(homedir(), '.claude'))) found.push('claude-code');
+  if (existsSync(join(homedir(), '.codex')) || commandExists('codex'))
+    found.push('codex');
+  if (existsSync(dirname(claudeDesktopConfigPath())))
+    found.push('claude-desktop');
+  if (existsSync(join(homedir(), '.cursor'))) found.push('cursor');
+  if (
+    existsSync(join(homedir(), '.windsurf')) ||
+    existsSync(join(homedir(), '.codeium'))
+  )
+    found.push('windsurf');
+  // Copilot is project-scoped: only when the current repo has a .github dir.
+  if (existsSync(join(process.cwd(), '.github'))) found.push('copilot');
+  return found;
+}
+
+async function runOneInstall(
+  target: InstallTarget,
+  opts: InstallOpts
+): Promise<void> {
+  switch (target) {
+    case 'claude-code':
+      return installClaudeCode(opts);
+    case 'codex':
+      return installCodex(opts);
+    case 'claude-desktop':
+      return installClaudeDesktop(opts);
+    case 'cursor':
+    case 'windsurf':
+    case 'copilot':
+      return installEditorRules(target, opts);
+  }
+}
+
+function printInstallHelp(): void {
+  console.log(`Usage: dgmo install [target] [--scope user|project] [--dry-run]
+
+With no target, auto-detects every installed AI assistant and sets up each one
+(no prompts). The only binary you ever install is \`dgmo\` — it provides the MCP
+server via \`dgmo mcp\`.
+
+Targets:   ${INSTALL_TARGETS.join(', ')}
+--scope    user = configure globally for all projects (default)
+           project = write config into the current directory
+--dry-run  print what would change without writing anything`);
+}
+
+// `dgmo install [target] [--scope ...] [--dry-run]`. No target → auto-detect.
+async function runInstallCommand(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printInstallHelp();
+    return;
+  }
+  const scopeIdx = args.indexOf('--scope');
+  const scope: 'user' | 'project' =
+    scopeIdx >= 0 && args[scopeIdx + 1] === 'project' ? 'project' : 'user';
+  const opts: InstallOpts = { scope, dryRun: args.includes('--dry-run') };
+
+  const positional = args.filter(
+    (a, i) => !a.startsWith('-') && args[i - 1] !== '--scope'
+  );
+  const target = positional[0] as InstallTarget | undefined;
+
+  console.log(renderBanner());
+
+  if (target) {
+    if (!INSTALL_TARGETS.includes(target)) {
+      console.error(`Error: Unknown install target "${target}".`);
+      console.error(`Valid targets: ${INSTALL_TARGETS.join(', ')}`);
+      process.exit(1);
+    }
+    await runOneInstall(target, opts);
+    console.log('\nRestart the assistant to activate the dgmo tools.');
+    return;
   }
 
-  console.log('\nRestart Claude Desktop to activate the MCP server.');
+  const detected = detectSurfaces();
+  if (detected.length === 0) {
+    console.log(
+      'No AI assistants detected (looked for Claude Code, Codex, Claude Desktop, Cursor, Windsurf, a .github dir).'
+    );
+    console.log('Install one and re-run `dgmo install`, or name a target:');
+    console.log(`  dgmo install <${INSTALL_TARGETS.join('|')}>`);
+    return;
+  }
+  console.log(`Detected: ${detected.join(', ')} — setting up each.\n`);
+  for (const t of detected) {
+    console.log(`── ${t} ──`);
+    await runOneInstall(t, opts);
+    console.log('');
+  }
+  console.log('Done. Restart your AI assistant(s) to activate the dgmo tools.');
+}
+
+async function installClaudeCode(opts: InstallOpts): Promise<void> {
+  const claudeDir = join(homedir(), '.claude');
+  // Skill — single-sourced and always refreshed to the maintained latest.
+  writeOut(
+    opts,
+    join(claudeDir, 'commands', 'dgmo.md'),
+    readClaudeSkill(),
+    'Skill → ~/.claude/commands/dgmo.md'
+  );
+  ensureDgmoMcp(opts);
+  if (opts.scope === 'user') {
+    upsertJsonMcp(opts, join(claudeDir, 'settings.json'));
+    console.log('  (scope: all projects)');
+  } else {
+    upsertJsonMcp(opts, join(process.cwd(), '.mcp.json'));
+    console.log('  (scope: this project)');
+  }
+  console.log('  Then type /dgmo in any Claude Code session.');
+}
+
+async function installCodex(opts: InstallOpts): Promise<void> {
+  ensureDgmoMcp(opts);
+
+  // MCP config (TOML). The block migrates in place if a legacy entry exists.
+  const tomlEntry = '[mcp_servers.dgmo]\ncommand = "dgmo"\nargs = ["mcp"]\n';
+  const configPath =
+    opts.scope === 'user'
+      ? join(homedir(), '.codex', 'config.toml')
+      : join(process.cwd(), '.codex', 'config.toml');
+  const existing = existsSync(configPath)
+    ? readFileSync(configPath, 'utf-8')
+    : '';
+  let next: string;
+  if (existing.includes('[mcp_servers.dgmo]')) {
+    next = existing.replace(/\[mcp_servers\.dgmo\][^[]*/, tomlEntry);
+  } else {
+    const sep = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+    next = existing + sep + tomlEntry;
+  }
+  writeOut(opts, configPath, next, `MCP server → ${configPath}`);
+
+  // Skill — single-sourced, always refreshed.
+  writeOut(
+    opts,
+    join(homedir(), '.codex', 'skills', 'dgmo-diagramming', 'SKILL.md'),
+    readCodexSkill(),
+    'Skill → ~/.codex/skills/dgmo-diagramming/SKILL.md'
+  );
+
+  // Non-destructive AGENTS.md note: only append to an existing file, never create.
+  const agentsPath = join(process.cwd(), 'AGENTS.md');
+  if (!opts.dryRun && existsSync(agentsPath)) {
+    const existingAgents = readFileSync(agentsPath, 'utf-8');
+    if (!existingAgents.includes(CODEX_AGENTS_NOTE_MARKER)) {
+      const separator = existingAgents.endsWith('\n') ? '\n' : '\n\n';
+      writeFileSync(
+        agentsPath,
+        existingAgents + separator + CODEX_AGENTS_NOTE,
+        'utf-8'
+      );
+      console.log('✓ Appended dgmo note to AGENTS.md');
+    }
+  }
+}
+
+async function installClaudeDesktop(opts: InstallOpts): Promise<void> {
+  ensureDgmoMcp(opts);
+  // Claude Desktop config is always the per-user app config (scope is N/A).
+  upsertJsonMcp(opts, claudeDesktopConfigPath());
+}
+
+// Cursor / Windsurf / Copilot are non-MCP: they read a project-root context
+// file. We ship those files in the package and copy them into the cwd. This
+// closes the former manual-copy gap for those editors.
+function installEditorRules(
+  kind: 'cursor' | 'windsurf' | 'copilot',
+  opts: InstallOpts
+): void {
+  const map = {
+    cursor: { src: ['.cursorrules'], dest: ['.cursorrules'] },
+    windsurf: { src: ['.windsurfrules'], dest: ['.windsurfrules'] },
+    copilot: {
+      src: ['.github', 'copilot-instructions.md'],
+      dest: ['.github', 'copilot-instructions.md'],
+    },
+  } as const;
+  const { src, dest } = map[kind];
+  writeOut(
+    opts,
+    join(process.cwd(), ...dest),
+    readPackagedFile(...src),
+    `${kind} context → ${join(...dest)}`
+  );
 }
 
 async function main(): Promise<void> {
@@ -836,6 +753,9 @@ async function main(): Promise<void> {
   if (sub === 'install') {
     await runInstallCommand(process.argv.slice(3));
     return;
+  }
+  if (sub === 'mcp') {
+    runMcpCommand(process.argv.slice(3));
   }
 
   const opts = parseArgs(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -430,9 +430,17 @@ function runMcpCommand(args: string[]): never {
   const onWin = process.platform === 'win32';
   const run = (cmd: string, cmdArgs: string[]) =>
     spawnSync(cmd, cmdArgs, { stdio: 'inherit', shell: onWin });
-  const res = commandExists('dgmo-mcp')
-    ? run('dgmo-mcp', args)
-    : run('npx', ['-y', '@diagrammo/dgmo-mcp', ...args]);
+  // npx path is pinned to @latest so the on-demand server is never stale.
+  const npx = () => run('npx', ['-y', '@diagrammo/dgmo-mcp@latest', ...args]);
+  // Default: prefer the installed binary — fast, works offline, and
+  // `dgmo install` keeps it on @latest. Set DGMO_MCP_LATEST=1 to always fetch
+  // the newest server via npx instead (needs network; adds cold-start).
+  const res =
+    process.env['DGMO_MCP_LATEST'] === '1'
+      ? npx()
+      : commandExists('dgmo-mcp')
+        ? run('dgmo-mcp', args)
+        : npx();
   if (res.error) {
     console.error(
       'Could not launch the dgmo MCP server. Install it with: npm install -g @diagrammo/dgmo-mcp'
@@ -483,21 +491,22 @@ let mcpEnsured = false;
 function ensureDgmoMcp(opts: InstallOpts): void {
   if (mcpEnsured) return;
   mcpEnsured = true;
-  if (commandExists('dgmo-mcp')) {
-    console.log('✓ MCP server present');
-    return;
-  }
   if (opts.dryRun) {
-    console.log('  [dry-run] would install @diagrammo/dgmo-mcp');
+    console.log('  [dry-run] would install/upgrade @diagrammo/dgmo-mcp@latest');
     return;
   }
+  // Always pull @latest, not just install-if-absent: the MCP tools live in a
+  // separately-versioned package, so re-running `dgmo install` (e.g. after a
+  // `dgmo` upgrade) is what refreshes the server. Non-fatal — `dgmo mcp` falls
+  // back to `npx …@latest`.
   try {
-    console.log('Installing the MCP server (one-time)…');
-    execSync('npm install -g @diagrammo/dgmo-mcp', { stdio: 'inherit' });
-    console.log('✓ MCP server installed');
+    const verb = commandExists('dgmo-mcp') ? 'Updating' : 'Installing';
+    console.log(`${verb} the MCP server (@diagrammo/dgmo-mcp@latest)…`);
+    execSync('npm install -g @diagrammo/dgmo-mcp@latest', { stdio: 'inherit' });
+    console.log('✓ MCP server up to date');
   } catch {
     console.log(
-      '  Could not pre-install — it will be fetched on first use via npx.'
+      '  Could not install now — it will be fetched on first use via npx.'
     );
   }
 }
@@ -620,6 +629,7 @@ async function runInstallCommand(args: string[]): Promise<void> {
     }
     await runOneInstall(target, opts);
     console.log('\nRestart the assistant to activate the dgmo tools.');
+    console.log('(Re-run `dgmo install` after upgrading dgmo to refresh.)');
     return;
   }
 
@@ -639,6 +649,7 @@ async function runInstallCommand(args: string[]): Promise<void> {
     console.log('');
   }
   console.log('Done. Restart your AI assistant(s) to activate the dgmo tools.');
+  console.log('(Re-run `dgmo install` after upgrading dgmo to refresh.)');
 }
 
 async function installClaudeCode(opts: InstallOpts): Promise<void> {


### PR DESCRIPTION
Makes AI tooling install one binary + one command, and keeps it current.

## CLI
- **`dgmo mcp`** subcommand launches the MCP server (execs `dgmo-mcp`, else `npx -y @diagrammo/dgmo-mcp@latest`). All generated client configs now use `{ command: "dgmo", args: ["mcp"] }` — one binary, no separate `dgmo-mcp` install, no dependency cycle, no extra deps in the render library.
- **`dgmo install`** with no target auto-detects Claude Code, Codex, Claude Desktop, Cursor, Windsurf, Copilot and configures each non-interactively. Flags: `--scope user|project` (default user), `--dry-run`. Cursor/Windsurf wired as real MCP clients.
- Removed the interactive prompt helper.

## Freshness
- `dgmo install` upgrades the server (`@diagrammo/dgmo-mcp@latest`), not just install-if-absent.
- `dgmo mcp` pins the npx fallback to `@latest`; opt-in `DGMO_MCP_LATEST=1` for always-newest-at-launch.
- `ensureDgmoMcp` is Homebrew-aware (skips npm-global when running from a Cellar prefix, so it won't shadow brew's bundled server).
- `release.yml` `bump-homebrew` now also pins the formula's dgmo-mcp resource (url+sha) so each dgmo release ships a tested CLI+server pair.

## Docs
README, `docs/ai-integration.md`, and the shipped `/dgmo` skill updated.

Validation: typecheck + lint clean, 6974 tests pass.

> Note: may conflict with `docs/ai-integration.md` if main's in-flight language-reference work has landed — reconcile on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)